### PR TITLE
re: "handle name in description", drop matches preceeded by "pfp"

### DIFF
--- a/src/lib/bskyHelpers.ts
+++ b/src/lib/bskyHelpers.ts
@@ -39,7 +39,8 @@ export const isSimilarUser = (names: Names, bskyProfile: ProfileView | undefined
     }
   }
 
-  if (bskyProfile.description?.toLocaleLowerCase().match(`(?<!pfp )@${lowerCaseNames.accountName}`)) {
+  const regexPattern = new RegExp(`(?<!pfp )@${lowerCaseNames.accountName}`, 'i');
+  if (bskyProfile.description?.match(regexPattern)) {
     return {
       isSimilar: true,
       type: BSKY_USER_MATCH_TYPE.DESCRIPTION,

--- a/src/lib/bskyHelpers.ts
+++ b/src/lib/bskyHelpers.ts
@@ -39,7 +39,7 @@ export const isSimilarUser = (names: Names, bskyProfile: ProfileView | undefined
     }
   }
 
-  if (bskyProfile.description?.toLocaleLowerCase().includes(`@${lowerCaseNames.accountName}`)) {
+  if (bskyProfile.description?.toLocaleLowerCase().match(`(?<!pfp )@${lowerCaseNames.accountName}`)) {
     return {
       isSimilar: true,
       type: BSKY_USER_MATCH_TYPE.DESCRIPTION,


### PR DESCRIPTION
"handle name in description" seems to give a lot of false positives for me, and a common reason is this:

![image](https://github.com/kawamataryo/sky-follower-bridge/assets/28416282/d78254f6-30d3-41ca-8b71-4aa06fcc775c)

Note here that `camalange` is just trying to give credit for their pic to `coughdrops`.

This PR attempts to filter out these false positives using a negative lookbehind and regex. (Please test it out in the project, I was only able to test the JS in console!) The regex means that when it hits a possible match, it will check to make sure it doesn't have "pfp " in front of it before matching. Hopefully.

There's a chance you will miss a few account matches due to this, but I hope you find it worth it for the false positives it filters out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the user matching logic to exclude certain patterns, enhancing the accuracy of similar user detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->