### PR TITLE
Alternate to #31

### DIFF
--- a/src/lib/bskyHelpers.ts
+++ b/src/lib/bskyHelpers.ts
@@ -39,7 +39,7 @@ export const isSimilarUser = (names: Names, bskyProfile: ProfileView | undefined
     }
   }
 
-  if (bskyProfile.description?.toLocaleLowerCase().includes(`@${lowerCaseNames.accountName}`) && !bskyProfile.description?.toLocaleLowerCase().includes(`pfp @${lowerCaseNames.accountName}`)) {
+  if (bskyProfile.description?.toLocaleLowerCase().includes(`@${lowerCaseNames.accountName}`) && !['pfp ', 'pfp: ', 'pfp by '].some(t => bskyProfile.description.toLocaleLowerCase().includes(`${t}@${lowerCaseNames.accountName}`))) {
     return {
       isSimilar: true,
       type: BSKY_USER_MATCH_TYPE.DESCRIPTION,

--- a/src/lib/bskyHelpers.ts
+++ b/src/lib/bskyHelpers.ts
@@ -39,7 +39,7 @@ export const isSimilarUser = (names: Names, bskyProfile: ProfileView | undefined
     }
   }
 
-  if (bskyProfile.description?.toLocaleLowerCase().includes(`@${lowerCaseNames.accountName}`)) {
+  if (bskyProfile.description?.toLocaleLowerCase().includes(`@${lowerCaseNames.accountName}`) && !bskyProfile.description?.toLocaleLowerCase().includes(`pfp @${lowerCaseNames.accountName}`)) {
     return {
       isSimilar: true,
       type: BSKY_USER_MATCH_TYPE.DESCRIPTION,


### PR DESCRIPTION
Will work on more browsers than #31, as it doesn't rely on regex.

![image](https://github.com/kawamataryo/sky-follower-bridge/assets/28416282/d914a2f5-f449-4bd8-834c-914b62e816c3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined the user similarity checking logic to consider specific phrases in the `bskyProfile` description that may indicate non-similarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->