### PR TITLE
Add "Microsoft Edge Add-ons" to installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ https://github.com/kawamataryo/sky-follower-bridge/assets/11070996/67bdd228-dc67
 
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko)
 - [Firefox Add-ons](https://addons.mozilla.org/ja/firefox/addon/sky-follower-bridge/)
+- [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/sky-follower-bridge/dpeolmdblhfolkhlhbhlofkkpaojnnbb)
 
 ## 🚀 How to use
 


### PR DESCRIPTION
Having the link there would help security-conscious/-paranoid users verify that the extension there was published by you and not someone impersonating you.

I found it by searching for the addon on Bing (just made a new profile and that was the default search engine). The developer link there leads to this GitHub repository, and the "other extensions by this developer" (appear to) match your extensions on the Chrome Web Store.

----

@kawamataryo Just to verify in case of impersonation: did you publish this extension on the Edge Add-ons site too? And is [this](https://microsoftedge.microsoft.com/addons/search?developer=Kawamata%20Ryo) your developer page?