### PR TITLE
Remove "@" from popup placeholder

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -226,7 +226,7 @@ function IndexPopup() {
           <input
             type="text"
             name="identifier"
-            placeholder="@you.bsky.social"
+            placeholder="your-username.bsky.social"
             value={identifier}
             onChange={(e) => setIdentifier(e.target.value)}
             className="input input-bordered input-sm w-full max-w-xs join-item focus:outline-none mt-1"


### PR DESCRIPTION
Went to use the extension, and was stumped trying to run the tool. 

Looks like my username without a leading `@` worked, and I was led astray on how to enter my username due to this placeholder.

Either that, or you support with `@` and without, and my app password just took a minute to become valid?