### PR TITLE
Add Safari links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ https://github.com/kawamataryo/sky-follower-bridge/assets/11070996/67bdd228-dc67
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko) (Recommended)
 - [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/sky-follower-bridge/)
 - [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/sky-follower-bridge/dpeolmdblhfolkhlhbhlofkkpaojnnbb)
+- [Mac App Store](https://apps.apple.com/us/app/sky-follower-bridge/id6738878242?mt=12) (for Safari)
 
 > [!NOTE]
 > We recommend using the Chrome Web Store version as it's always up to date. Other store versions may lag behind in updates.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -13,6 +13,7 @@ Sky Follower Bridge is available on:
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko) (Recommended)
 - [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/sky-follower-bridge/)
 - [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/sky-follower-bridge/dpeolmdblhfolkhlhbhlofkkpaojnnbb)
+- [Mac App Store](https://apps.apple.com/us/app/sky-follower-bridge/id6738878242?mt=12) (for Safari)
 
 ::: tip
 We recommend using the Chrome Web Store version as it's always up to date. Other store versions may lag behind in updates.


### PR DESCRIPTION
Add links to the Safari extension on the Mac App Store, allowing users of Safari on Mac to be able to import their followers using Sky Follower Bridge. 

This version was ported to Safari but maintains exact feature parody with the Chrome version.