### PR TITLE
fix(README): Remove references to `dist` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ After building, you can load the extension:
 **For Firefox:**
 1. Go to `about:debugging#/runtime/this-firefox`
 2. Click "Load Temporary Add-on"
-3. Select the zip file from the `dist` directory
+3. Select the zip file from the `build` directory
 
 ### Notes
 - The built extension will be in the `build` directory
-- The packaged extension (.zip) will be in the `dist` directory
 - When using a custom PDS, users will need to use handles in the format `username.your-custom-domain.com`
 - Make sure your custom PDS server is compatible with the AT Protocol


### PR DESCRIPTION
Hi! I noticed that when I build & package, I didn't see the `dist` directory as described in the README. Instead, I noticed that the packaged .zip file was in the `build` directory. So, I'm suggesting this tiny fix to the README. 

Hope this helps!