### PR TITLE
fix: handle undefined accountName in xService extractUserData

### DIFF
--- a/src/services/xService.ts
+++ b/src/services/xService.ts
@@ -56,7 +56,7 @@ export class XService implements IService {
   extractUserData(userCell: Element): CrawledUserInfo {
     const anchors = Array.from(userCell.querySelectorAll("a"));
     const [avatarEl, displayNameEl] = anchors;
-    const accountName = avatarEl?.getAttribute("href")?.replace("/", "");
+    const accountName = avatarEl?.getAttribute("href")?.replace("/", "") ?? "";
     const accountNameRemoveUnderscore = accountName.replaceAll("_", ""); // bsky does not allow underscores in handle, so remove them.
     const accountNameReplaceUnderscore = accountName.replaceAll("_", "-");
     const displayName = displayNameEl?.textContent;


### PR DESCRIPTION
## Summary
- Fix TypeError when `avatarEl.getAttribute("href")` returns undefined
- Add nullish coalescing operator (`??`) to default to empty string when accountName is undefined
- Prevents "can't access property 'replaceAll', o is undefined" error

## Background
Issue #171 reported a bug where the extension would crash with a TypeError when processing X users with emoji-only display names (e.g., 🍵). The error occurred in `xService.ts:62` when trying to call `replaceAll()` on an undefined value.

## Root Cause
In the `extractUserData` method, when `avatarEl?.getAttribute("href")` returns undefined (which can happen with certain DOM structures), the subsequent calls to `replaceAll()` on line 62-63 would fail.

## Solution
Added nullish coalescing operator (`?? ""`) on line 61 to ensure `accountName` always has a string value, even if the href attribute is missing or undefined.

## Test Plan
- [x] Ran `npm run check` (Biome linter/formatter) - Passed
- [x] Ran `npm run test` (Vitest) - All 10 tests passed
- [x] Pre-commit hooks executed successfully

## Related
Fixes #171