### PR TITLE
chore: upgrade Biome to 2.3.13 and fix lint errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,21 +1,22 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
-	"formatter": {
-		"indentStyle": "space"
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"a11y": {
-				"noSvgWithoutTitle": "off"
-			},
-			"security": {
-				"noDangerouslySetInnerHtml": "off"
-			}
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "formatter": {
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "noSvgWithoutTitle": "off"
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "off"
+      },
+      "suspicious": {
+        "noUnknownAtRules": "off"
+      }
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sky-follower-bridge",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sky-follower-bridge",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "dependencies": {
         "@atproto/api": "^0.13.12",
         "@changesets/cli": "^2.27.1",
@@ -29,7 +29,7 @@
         "vitepress": "^1.5.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.9.3",
+        "@biomejs/biome": "^2.3.13",
         "@chromatic-com/storybook": "^3.2.2",
         "@plasmohq/prettier-plugin-sort-imports": "4.0.1",
         "@storybook/addon-essentials": "^8.4.5",
@@ -832,11 +832,11 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.3.tgz",
-      "integrity": "sha512-POjAPz0APAmX33WOQFGQrwLvlu7WLV4CFJMlB12b6ZSg+2q6fYu9kZwLCOA+x83zXfcPd1RpuWOKJW0GbBwLIQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
       },
@@ -848,24 +848,25 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.3",
-        "@biomejs/cli-darwin-x64": "1.9.3",
-        "@biomejs/cli-linux-arm64": "1.9.3",
-        "@biomejs/cli-linux-arm64-musl": "1.9.3",
-        "@biomejs/cli-linux-x64": "1.9.3",
-        "@biomejs/cli-linux-x64-musl": "1.9.3",
-        "@biomejs/cli-win32-arm64": "1.9.3",
-        "@biomejs/cli-win32-x64": "1.9.3"
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.3.tgz",
-      "integrity": "sha512-QZzD2XrjJDUyIZK+aR2i5DDxCJfdwiYbUKu9GzkCUJpL78uSelAHAPy7m0GuPMVtF/Uo+OKv97W3P9nuWZangQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -875,13 +876,14 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.3.tgz",
-      "integrity": "sha512-vSCoIBJE0BN3SWDFuAY/tRavpUtNoqiceJ5PrU3xDfsLcm/U6N93JSM0M9OAiC/X7mPPfejtr6Yc9vSgWlEgVw==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -891,13 +893,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.3.tgz",
-      "integrity": "sha512-vJkAimD2+sVviNTbaWOGqEBy31cW0ZB52KtpVIbkuma7PlfII3tsLhFa+cwbRAcRBkobBBhqZ06hXoZAN8NODQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -907,13 +910,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.3.tgz",
-      "integrity": "sha512-VBzyhaqqqwP3bAkkBrhVq50i3Uj9+RWuj+pYmXrMDgjS5+SKYGE56BwNw4l8hR3SmYbLSbEo15GcV043CDSk+Q==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -923,13 +927,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.3.tgz",
-      "integrity": "sha512-x220V4c+romd26Mu1ptU+EudMXVS4xmzKxPVb9mgnfYlN4Yx9vD5NZraSx/onJnd3Gh/y8iPUdU5CDZJKg9COA==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -939,13 +944,14 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.3.tgz",
-      "integrity": "sha512-TJmnOG2+NOGM72mlczEsNki9UT+XAsMFAOo8J0me/N47EJ/vkLXxf481evfHLlxMejTY6IN8SdRSiPVLv6AHlA==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -955,13 +961,14 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.3.tgz",
-      "integrity": "sha512-lg/yZis2HdQGsycUvHWSzo9kOvnGgvtrYRgoCEwPBwwAL8/6crOp3+f47tPwI/LI1dZrhSji7PNsGKGHbwyAhw==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -971,13 +978,14 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.3.tgz",
-      "integrity": "sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -20545,74 +20553,74 @@
       }
     },
     "@biomejs/biome": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.3.tgz",
-      "integrity": "sha512-POjAPz0APAmX33WOQFGQrwLvlu7WLV4CFJMlB12b6ZSg+2q6fYu9kZwLCOA+x83zXfcPd1RpuWOKJW0GbBwLIQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
       "dev": true,
       "requires": {
-        "@biomejs/cli-darwin-arm64": "1.9.3",
-        "@biomejs/cli-darwin-x64": "1.9.3",
-        "@biomejs/cli-linux-arm64": "1.9.3",
-        "@biomejs/cli-linux-arm64-musl": "1.9.3",
-        "@biomejs/cli-linux-x64": "1.9.3",
-        "@biomejs/cli-linux-x64-musl": "1.9.3",
-        "@biomejs/cli-win32-arm64": "1.9.3",
-        "@biomejs/cli-win32-x64": "1.9.3"
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
       }
     },
     "@biomejs/cli-darwin-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.3.tgz",
-      "integrity": "sha512-QZzD2XrjJDUyIZK+aR2i5DDxCJfdwiYbUKu9GzkCUJpL78uSelAHAPy7m0GuPMVtF/Uo+OKv97W3P9nuWZangQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-darwin-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.3.tgz",
-      "integrity": "sha512-vSCoIBJE0BN3SWDFuAY/tRavpUtNoqiceJ5PrU3xDfsLcm/U6N93JSM0M9OAiC/X7mPPfejtr6Yc9vSgWlEgVw==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.3.tgz",
-      "integrity": "sha512-vJkAimD2+sVviNTbaWOGqEBy31cW0ZB52KtpVIbkuma7PlfII3tsLhFa+cwbRAcRBkobBBhqZ06hXoZAN8NODQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.3.tgz",
-      "integrity": "sha512-VBzyhaqqqwP3bAkkBrhVq50i3Uj9+RWuj+pYmXrMDgjS5+SKYGE56BwNw4l8hR3SmYbLSbEo15GcV043CDSk+Q==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.3.tgz",
-      "integrity": "sha512-x220V4c+romd26Mu1ptU+EudMXVS4xmzKxPVb9mgnfYlN4Yx9vD5NZraSx/onJnd3Gh/y8iPUdU5CDZJKg9COA==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.3.tgz",
-      "integrity": "sha512-TJmnOG2+NOGM72mlczEsNki9UT+XAsMFAOo8J0me/N47EJ/vkLXxf481evfHLlxMejTY6IN8SdRSiPVLv6AHlA==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-win32-arm64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.3.tgz",
-      "integrity": "sha512-lg/yZis2HdQGsycUvHWSzo9kOvnGgvtrYRgoCEwPBwwAL8/6crOp3+f47tPwI/LI1dZrhSji7PNsGKGHbwyAhw==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
       "dev": true,
       "optional": true
     },
     "@biomejs/cli-win32-x64": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.3.tgz",
-      "integrity": "sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vitepress": "^1.5.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.3",
+    "@biomejs/biome": "^2.3.13",
     "@chromatic-com/storybook": "^3.2.2",
     "@plasmohq/prettier-plugin-sort-imports": "4.0.1",
     "@storybook/addon-essentials": "^8.4.5",

--- a/src/background/messages/openOptionPage.ts
+++ b/src/background/messages/openOptionPage.ts
@@ -1,6 +1,6 @@
 import type { PlasmoMessaging } from "@plasmohq/messaging";
 
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+const handler: PlasmoMessaging.MessageHandler = async (_req, _res) => {
   chrome.runtime.openOptionsPage(() => {
     if (chrome.runtime.lastError) {
       console.error(chrome.runtime.lastError);

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type ActionButtonProps = {
   loading: boolean;
   actionBtnLabelAndClass: { label: string; class: string };

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -59,7 +59,7 @@ const useConfirm = ({
   const [promise, setPromise] = useState(null);
 
   const confirm = () => {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       setPromise({ resolve });
     });
   };

--- a/src/components/DetectedUserListItem.stories.tsx
+++ b/src/components/DetectedUserListItem.stories.tsx
@@ -58,7 +58,7 @@ const CardsTemplate: Story = {
     <div className="divide-y divide-gray-400 border-y border-gray-400">
       {args.items.map((arg, i) => (
         <DetectedUserListItem
-          // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+          // biome-ignore lint/suspicious/noArrayIndexKey: Storybook example data
           key={i}
           user={arg.user}
           clickAction={arg.action}

--- a/src/components/DetectedUserSource.tsx
+++ b/src/components/DetectedUserSource.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { BskyUser } from "~types";
 import UserInfo from "./UserInfo";
 import UserProfile from "./UserProfile";

--- a/src/components/DonationCard.tsx
+++ b/src/components/DonationCard.tsx
@@ -37,65 +37,64 @@ const DonationCard = () => {
   }, [userClosed]);
 
   return (
-    <>
-      <AnimatePresence>
-        {isVisible && (
-          <motion.div
-            className="card bg-neutral text-neutral-content shadow-lg w-[426px] relative"
-            initial={{ y: "100%", opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: "100%", opacity: 0 }}
-            transition={{ type: "spring", stiffness: 50, damping: 10 }}
-          >
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
-            <div className="card-body p-4 cursor-pointer" onClick={handleClose}>
-              <div className="flex gap-2 items-center">
-                <p
-                  className="text-sm"
-                  dangerouslySetInnerHTML={{
-                    __html: getMessageWithLink("donate_message"),
-                  }}
-                />
-                <button
-                  type="button"
-                  onClick={handleDonationLinkClick}
-                  style={{ display: "inline-block" }}
-                  className="w-full"
-                >
-                  <img
-                    src="https://storage.ko-fi.com/cdn/kofi1.png?v=6"
-                    alt="Buy Me a Coffee at ko-fi.com"
-                    className="w-[120px] h-auto m-auto"
-                  />
-                </button>
-              </div>
-            </div>
-            <div className="absolute top-[-10px] right-[-10px]">
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          className="card bg-neutral text-neutral-content shadow-lg w-[426px] relative"
+          initial={{ y: "100%", opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: "100%", opacity: 0 }}
+          transition={{ type: "spring", stiffness: 50, damping: 10 }}
+        >
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: Close action triggered by parent */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: Interactive card component */}
+          <div className="card-body p-4 cursor-pointer" onClick={handleClose}>
+            <div className="flex gap-2 items-center">
+              <p
+                className="text-sm"
+                dangerouslySetInnerHTML={{
+                  __html: getMessageWithLink("donate_message"),
+                }}
+              />
               <button
-                className="btn btn-circle btn-sm bg-neutral text-neutral-content"
                 type="button"
-                onClick={handleClose}
+                onClick={handleDonationLinkClick}
+                style={{ display: "inline-block" }}
+                className="w-full"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
+                <img
+                  src="https://storage.ko-fi.com/cdn/kofi1.png?v=6"
+                  alt="Buy Me a Coffee at ko-fi.com"
+                  className="w-[120px] h-auto m-auto"
+                />
               </button>
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </>
+          </div>
+          <div className="absolute top-[-10px] right-[-10px]">
+            <button
+              className="btn btn-circle btn-sm bg-neutral text-neutral-content"
+              type="button"
+              onClick={handleClose}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 };
 

--- a/src/components/LoadingCards.tsx
+++ b/src/components/LoadingCards.tsx
@@ -22,7 +22,7 @@ const LoadingCards = () => {
     );
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Animation effect runs independently
   React.useEffect(() => {
     const interval = setInterval(() => {
       moveToEnd(0);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -76,32 +76,30 @@ const Modal = ({
   }, []);
 
   return (
-    <>
-      <dialog className="modal" ref={anchorRef} open={open}>
-        <div
-          className="modal-box p-10 bg-base-100 max-w-none text-base-content absolute cursor-move"
-          style={{ width }}
-          ref={modalContainerRef}
-        >
-          {hasCloseButton && (
-            <form method="dialog">
-              <button
-                type="submit"
-                className="btn btn-sm btn-circle absolute right-2 top-2"
-              >
-                ✕
-              </button>
-            </form>
-          )}
-          <div className="cursor-auto">{children}</div>
-        </div>
-        {isCloseOnOverlayClick && (
-          <form method="dialog" className="modal-backdrop">
-            <button type="submit">close</button>
+    <dialog className="modal" ref={anchorRef} open={open}>
+      <div
+        className="modal-box p-10 bg-base-100 max-w-none text-base-content absolute cursor-move"
+        style={{ width }}
+        ref={modalContainerRef}
+      >
+        {hasCloseButton && (
+          <form method="dialog">
+            <button
+              type="submit"
+              className="btn btn-sm btn-circle absolute right-2 top-2"
+            >
+              ✕
+            </button>
           </form>
         )}
-      </dialog>
-    </>
+        <div className="cursor-auto">{children}</div>
+      </div>
+      {isCloseOnOverlayClick && (
+        <form method="dialog" className="modal-backdrop">
+          <button type="submit">close</button>
+        </form>
+      )}
+    </dialog>
   );
 };
 

--- a/src/components/ServiceAlert.tsx
+++ b/src/components/ServiceAlert.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type Props = {
   serviceName: string;
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,13 +20,19 @@ type Props = {
   matchTypeStats: Record<Exclude<MatchType, "none">, number>;
   importList: ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => Promise<void>;
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => Promise<void>;
   followAll: ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => Promise<void>;
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => Promise<void>;
   blockAll: ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => Promise<void>;
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => Promise<void>;
 };
 
 const Sidebar = ({

--- a/src/components/UserCard.stories.tsx
+++ b/src/components/UserCard.stories.tsx
@@ -52,12 +52,12 @@ const CardTemplate = {
   ),
 };
 
-const CardsTemplate: Story = {
+const _CardsTemplate: Story = {
   render: (args) => (
     <div className="divide-y divide-gray-400 border-y border-gray-400">
       {args.items.map((arg, i) => (
         <UserCard
-          // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+          // biome-ignore lint/suspicious/noArrayIndexKey: Storybook example data
           key={i}
           user={arg.user}
           loading={false}

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,14 +1,9 @@
-import React from "react";
 import type { BskyUser } from "~types";
 import ActionButton from "./ActionButton";
 import UserInfo from "./UserInfo";
 import UserProfile from "./UserProfile";
 
-const DeleteButton = ({
-  onClick,
-}: {
-  onClick: () => void;
-}) => {
+const DeleteButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <div className="tooltip" data-tip={chrome.i18n.getMessage("delete_user")}>
       <button
@@ -35,11 +30,7 @@ const DeleteButton = ({
   );
 };
 
-const ReSearchButton = ({
-  onClick,
-}: {
-  onClick: () => void;
-}) => {
+const ReSearchButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <div className="tooltip" data-tip={chrome.i18n.getMessage("search_again")}>
       <button

--- a/src/components/UserCardWithoutActionButton.tsx
+++ b/src/components/UserCardWithoutActionButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { BskyUser } from "~types";
 import UserInfo from "./UserInfo";
 import UserProfile from "./UserProfile";

--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type UserInfoProps = {
   handle: string;
   displayName: string;
@@ -20,7 +18,7 @@ export const UserInfo = ({ handle, displayName, url }: UserInfoProps) => (
           {displayName}
         </a>
       ) : (
-        <>{displayName}</>
+        displayName
       )}
     </h2>
     <p className="w-fit break-word text-gray-500 dark:text-gray-400 text-sm">

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import AvatarFallbackSvg from "./Icons/AvatarFallbackSvg";
 
 type UserProfileProps = {

--- a/src/components/popup/Contact.tsx
+++ b/src/components/popup/Contact.tsx
@@ -1,5 +1,3 @@
-import type React from "react";
-
 export const Contact = () => {
   return (
     <div className="flex gap-2 items-start p-2 rounded-md text-xs bg-slate-100 dark:bg-slate-800">

--- a/src/components/popup/Header.tsx
+++ b/src/components/popup/Header.tsx
@@ -1,5 +1,3 @@
-import packageJson from "../../../package.json";
-
 interface HeaderProps {
   version: string;
 }

--- a/src/components/popup/Hint.tsx
+++ b/src/components/popup/Hint.tsx
@@ -1,5 +1,3 @@
-import type React from "react";
-
 export const Hint = () => {
   const handleNavigate = (url: string) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/src/contents/App.tsx
+++ b/src/contents/App.tsx
@@ -112,86 +112,84 @@ const App = () => {
   }, [currentService]);
 
   return (
-    <>
-      <Modal
-        open={isModalOpen}
-        onClose={closeModal}
-        hasCloseButton
-        isCloseOnOverlayClick={false}
-        width={550}
-      >
-        {currentService !== SERVICE_TYPE.X && loading && (
-          <ServiceAlert serviceName={serviceName} />
+    <Modal
+      open={isModalOpen}
+      onClose={closeModal}
+      hasCloseButton
+      isCloseOnOverlayClick={false}
+      width={550}
+    >
+      {currentService !== SERVICE_TYPE.X && loading && (
+        <ServiceAlert serviceName={serviceName} />
+      )}
+      <div className="flex flex-col gap-2 items-center">
+        {loading && (
+          <p className="text-lg font-bold">
+            {chrome.i18n.getMessage("scanning_users", [
+              serviceName,
+              scannedUserCount.toLocaleString(),
+            ])}
+          </p>
         )}
-        <div className="flex flex-col gap-2 items-center">
-          {loading && (
-            <p className="text-lg font-bold">
-              {chrome.i18n.getMessage("scanning_users", [
-                serviceName,
-                scannedUserCount.toLocaleString(),
-              ])}
-            </p>
-          )}
-          <p
-            className="text-2xl font-bold"
-            dangerouslySetInnerHTML={{
-              __html: chrome.i18n.getMessage("detected_users", [
-                users.length.toString(),
-              ]),
-            }}
-          />
-          {errorMessage && <AlertError>{errorMessage}</AlertError>}
-          {loading && (
-            <>
-              <button
-                type="button"
-                className="btn btn-primary mt-5 btn-ghost"
-                onClick={stopAndShowDetectedUsers}
-              >
-                {chrome.i18n.getMessage("stop_scanning_and_view_results")}
-              </button>
-              <LoadingCards />
-            </>
-          )}
-          {!loading && !isBottomReached && (
-            <div className="flex flex-col gap-2 items-center">
-              <button
-                type="button"
-                className="btn btn-primary mt-5 btn-ghost"
-                onClick={openOptionPage}
-              >
-                {chrome.i18n.getMessage("view_detected_users")}
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary mt-5"
-                onClick={restart}
-              >
-                {chrome.i18n.getMessage("resume_scanning")}
-              </button>
-            </div>
-          )}
-          {!loading && isBottomReached && (
-            <div className="flex flex-col gap-2 items-center">
-              <button
-                type="button"
-                className="btn btn-primary mt-5"
-                onClick={openOptionPage}
-              >
-                {chrome.i18n.getMessage("view_detected_users")}
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary mt-5 btn-ghost"
-                onClick={restart}
-              >
-                {chrome.i18n.getMessage("resume_scanning")}
-              </button>
-            </div>
-          )}
-        </div>
-      </Modal>
-    </>
+        <p
+          className="text-2xl font-bold"
+          dangerouslySetInnerHTML={{
+            __html: chrome.i18n.getMessage("detected_users", [
+              users.length.toString(),
+            ]),
+          }}
+        />
+        {errorMessage && <AlertError>{errorMessage}</AlertError>}
+        {loading && (
+          <>
+            <button
+              type="button"
+              className="btn btn-primary mt-5 btn-ghost"
+              onClick={stopAndShowDetectedUsers}
+            >
+              {chrome.i18n.getMessage("stop_scanning_and_view_results")}
+            </button>
+            <LoadingCards />
+          </>
+        )}
+        {!loading && !isBottomReached && (
+          <div className="flex flex-col gap-2 items-center">
+            <button
+              type="button"
+              className="btn btn-primary mt-5 btn-ghost"
+              onClick={openOptionPage}
+            >
+              {chrome.i18n.getMessage("view_detected_users")}
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary mt-5"
+              onClick={restart}
+            >
+              {chrome.i18n.getMessage("resume_scanning")}
+            </button>
+          </div>
+        )}
+        {!loading && isBottomReached && (
+          <div className="flex flex-col gap-2 items-center">
+            <button
+              type="button"
+              className="btn btn-primary mt-5"
+              onClick={openOptionPage}
+            >
+              {chrome.i18n.getMessage("view_detected_users")}
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary mt-5 btn-ghost"
+              onClick={restart}
+            >
+              {chrome.i18n.getMessage("resume_scanning")}
+            </button>
+          </div>
+        )}
+      </div>
+    </Modal>
   );
 };
 

--- a/src/contents/Profile.tsx
+++ b/src/contents/Profile.tsx
@@ -1,7 +1,7 @@
 import cssText from "data-text:~style.content.css";
 import type { AtpSessionData } from "@atproto/api";
 import type { PlasmoCSConfig } from "plasmo";
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import Modal from "~components/Modal";
 import { ProfileDetectedUserListItem } from "~components/ProfileDetectedUserListItem";
@@ -43,7 +43,7 @@ const hasValidSession = async (session: AtpSessionData) => {
     const client = new BskyServiceWorkerClient(session);
     await client.getMyProfile();
     isValid = true;
-  } catch (e) {
+  } catch (_e) {
     isValid = false;
   }
   debugLog({ isValidSession: isValid });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -104,7 +104,7 @@ export const useAuth = () => {
       setAuthFactorToken("");
       setIsShowAuthFactorTokenInput(false);
       clearErrorMessage();
-    } catch (e) {
+    } catch (_e) {
       setErrorMessage(
         chrome.i18n.getMessage("error_something_went_wrong"),
         DOCUMENT_LINK.OTHER_ERROR,
@@ -192,7 +192,7 @@ export const useAuth = () => {
       await clearPasswordFromStorage();
       await saveShowAuthFactorTokenInputToStorage(false);
       setIsAuthenticated(true);
-    } catch (e) {
+    } catch (_e) {
       setErrorMessage(
         chrome.i18n.getMessage("error_something_went_wrong"),
         DOCUMENT_LINK.OTHER_ERROR,

--- a/src/hooks/useBskyUserManager.ts
+++ b/src/hooks/useBskyUserManager.ts
@@ -11,8 +11,8 @@ import {
   BSKY_USER_MATCH_TYPE,
   DEFAULT_LIST_NAME,
   FILTER_TYPE,
-  type MESSAGE_NAMES,
   MESSAGE_NAME_TO_ACTION_MODE_MAP,
+  type MESSAGE_NAMES,
   STORAGE_KEYS,
 } from "~lib/constants";
 import { reSearchBskyUser } from "~lib/reSearchBskyUsers";
@@ -137,7 +137,9 @@ export const useBskyUserManager = () => {
   const importList = React.useCallback(
     async ({
       includeNonAvatarSimilarUsers,
-    }: { includeNonAvatarSimilarUsers: boolean }) => {
+    }: {
+      includeNonAvatarSimilarUsers: boolean;
+    }) => {
       if (!bskyClient.current) return;
       const storage = new Storage({
         area: "local",
@@ -148,7 +150,7 @@ export const useBskyUserManager = () => {
           includeNonAvatarSimilarUsers ||
           user.avatarSimilarityScore > AVATAR_SIMILARITY_SCORE_THRESHOLD,
       );
-      const listUri = await bskyClient.current.createListAndAddUsers({
+      const _listUri = await bskyClient.current.createListAndAddUsers({
         name: listName || DEFAULT_LIST_NAME,
         description: "List imported via Sky Follower Bridge",
         userDids: _filteredUsers.map((user) => user.did),
@@ -165,7 +167,9 @@ export const useBskyUserManager = () => {
   const followAll = React.useCallback(
     async ({
       includeNonAvatarSimilarUsers,
-    }: { includeNonAvatarSimilarUsers: boolean }) => {
+    }: {
+      includeNonAvatarSimilarUsers: boolean;
+    }) => {
       if (!bskyClient.current) return;
       let actionCount = 0;
       const _filteredUsers = filteredUsers.filter(
@@ -205,7 +209,9 @@ export const useBskyUserManager = () => {
   const blockAll = React.useCallback(
     async ({
       includeNonAvatarSimilarUsers,
-    }: { includeNonAvatarSimilarUsers: boolean }) => {
+    }: {
+      includeNonAvatarSimilarUsers: boolean;
+    }) => {
       if (!bskyClient.current) return;
       let actionCount = 0;
       const _filteredUsers = filteredUsers.filter(

--- a/src/hooks/useRetrieveBskyUsers.ts
+++ b/src/hooks/useRetrieveBskyUsers.ts
@@ -1,11 +1,10 @@
 import type { AtpSessionData } from "@atproto/api";
-import type { ProfileView } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import { sendToBackground } from "@plasmohq/messaging";
 import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/hook";
 import consola from "consola";
 import React, { useEffect } from "react";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { BskyServiceWorkerClient } from "~lib/bskyServiceWorkerClient";
 import { getChromeStorage } from "~lib/chromeHelper";
 import { MESSAGE_NAMES, SERVICE_TYPE, STORAGE_KEYS } from "~lib/constants";
@@ -212,7 +211,7 @@ export const useRetrieveBskyUsers = () => {
     }
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Initialize only once on mount
   const initialize = React.useCallback(async () => {
     const storage = await getChromeStorage<{
       [STORAGE_KEYS.BSKY_CLIENT_SESSION]: AtpSessionData;

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,7 +1,7 @@
 import { sendToContentScript } from "@plasmohq/messaging";
 import consola from "consola";
 import { useState } from "react";
-import { P, match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import {
   getChromeActiveTab,
   reloadChromeActiveTab,

--- a/src/lib/bskyClient.ts
+++ b/src/lib/bskyClient.ts
@@ -1,7 +1,6 @@
-import { AtUri, AtpAgent, type AtpSessionData } from "@atproto/api";
+import { AtpAgent, type AtpSessionData, AtUri } from "@atproto/api";
 import destr from "destr";
 import { BSKY_DOMAIN } from "./constants";
-import { debugLog } from "./utils";
 
 // try and cut down the amount of session resumes by caching the clients
 const clientCache = new Map<string, BskyClient>();
@@ -25,7 +24,7 @@ export class BskyClient {
   private constructor() {
     this.agent = new AtpAgent({
       service: this.service,
-      persistSession: (evt, session) => {
+      persistSession: (_evt, session) => {
         this.session = session;
       },
     });

--- a/src/lib/domHelpers.ts
+++ b/src/lib/domHelpers.ts
@@ -1,7 +1,10 @@
 export const getUserCells = ({
   queryParam,
   filterInsertedElement,
-}: { queryParam: string; filterInsertedElement: boolean }) => {
+}: {
+  queryParam: string;
+  filterInsertedElement: boolean;
+}) => {
   const userCells = document.querySelectorAll(queryParam);
 
   // filter out already inserted elements

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -52,7 +52,9 @@ const Option = () => {
 
   const handleFollowAll = async ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => {
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => {
     if (!(await followAllConfirm())) {
       return;
     }
@@ -74,7 +76,9 @@ const Option = () => {
 
   const handleBlockAll = async ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => {
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => {
     if (!(await followAllConfirm())) {
       return;
     }
@@ -96,7 +100,9 @@ const Option = () => {
 
   const handleImportList = async ({
     includeNonAvatarSimilarUsers,
-  }: { includeNonAvatarSimilarUsers: boolean }) => {
+  }: {
+    includeNonAvatarSimilarUsers: boolean;
+  }) => {
     if (!(await importListConfirm())) {
       return;
     }
@@ -171,70 +177,68 @@ const Option = () => {
   });
 
   return (
-    <>
-      <div className="flex h-screen">
-        <div className="fixed top-0 left-0 h-full">
-          <Sidebar
-            detectedCount={users.length}
-            filterValue={matchTypeFilter}
-            onChangeFilter={changeMatchTypeFilter}
-            actionMode={actionMode}
-            matchTypeStats={matchTypeStats}
-            importList={handleImportList}
-            followAll={handleFollowAll}
-            blockAll={handleBlockAll}
-          />
-        </div>
-        <div className="flex-1 ml-80 p-6 pt-0 overflow-y-auto">
-          <div className="grid grid-cols-[22%_1fr] sticky top-0 z-10 bg-base-100 border-b-[1px] border-gray-500">
-            <h2 className="text-lg font-bold text-center py-2">
-              {chrome.i18n.getMessage("source")}
-            </h2>
-            <h2 className="text-lg font-bold text-center py-2">
-              {chrome.i18n.getMessage("detected")}
-            </h2>
-          </div>
-          <div
-            className="flex flex-col border-b-[1px] border-gray-500"
-            ref={parentRef}
-            data-testid="scroll-parent"
-          >
-            {rowVirtualizer.getVirtualItems().map((virtualItem) => (
-              <div
-                key={virtualItem.key}
-                data-index={virtualItem.index}
-                ref={rowVirtualizer.measureElement}
-              >
-                <DetectedUserListItem
-                  key={filteredUsers[virtualItem.index].handle}
-                  user={filteredUsers[virtualItem.index]}
-                  clickAction={handleClickAction}
-                  actionMode={actionMode}
-                  reSearch={handleReSearch}
-                  deleteUser={deleteUser}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="fixed bottom-5 right-5">
-          <DonationCard />
-        </div>
-        <ReSearchModal
-          open={showReSearchModal}
-          onClose={handleCloseReSearchModal}
-          reSearchResults={reSearchResults}
-          handleClickReSearchResult={handleClickReSearchResult}
+    <div className="flex h-screen">
+      <div className="fixed top-0 left-0 h-full">
+        <Sidebar
+          detectedCount={users.length}
+          filterValue={matchTypeFilter}
+          onChangeFilter={changeMatchTypeFilter}
+          actionMode={actionMode}
+          matchTypeStats={matchTypeStats}
+          importList={handleImportList}
+          followAll={handleFollowAll}
+          blockAll={handleBlockAll}
         />
-        <ToastContainer
-          position="top-right"
-          autoClose={5000}
-          className="text-sm"
-        />
-        <FollowAllConfirmationDialog />
-        <ImportListConfirmationDialog />
       </div>
-    </>
+      <div className="flex-1 ml-80 p-6 pt-0 overflow-y-auto">
+        <div className="grid grid-cols-[22%_1fr] sticky top-0 z-10 bg-base-100 border-b-[1px] border-gray-500">
+          <h2 className="text-lg font-bold text-center py-2">
+            {chrome.i18n.getMessage("source")}
+          </h2>
+          <h2 className="text-lg font-bold text-center py-2">
+            {chrome.i18n.getMessage("detected")}
+          </h2>
+        </div>
+        <div
+          className="flex flex-col border-b-[1px] border-gray-500"
+          ref={parentRef}
+          data-testid="scroll-parent"
+        >
+          {rowVirtualizer.getVirtualItems().map((virtualItem) => (
+            <div
+              key={virtualItem.key}
+              data-index={virtualItem.index}
+              ref={rowVirtualizer.measureElement}
+            >
+              <DetectedUserListItem
+                key={filteredUsers[virtualItem.index].handle}
+                user={filteredUsers[virtualItem.index]}
+                clickAction={handleClickAction}
+                actionMode={actionMode}
+                reSearch={handleReSearch}
+                deleteUser={deleteUser}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="fixed bottom-5 right-5">
+        <DonationCard />
+      </div>
+      <ReSearchModal
+        open={showReSearchModal}
+        onClose={handleCloseReSearchModal}
+        reSearchResults={reSearchResults}
+        handleClickReSearchResult={handleClickReSearchResult}
+      />
+      <ToastContainer
+        position="top-right"
+        autoClose={5000}
+        className="text-sm"
+      />
+      <FollowAllConfirmationDialog />
+      <ImportListConfirmationDialog />
+    </div>
   );
 };
 

--- a/src/services/xService.ts
+++ b/src/services/xService.ts
@@ -1,7 +1,5 @@
 import { Storage } from "@plasmohq/storage";
-import { MESSAGE_NAMES } from "~lib/constants";
-import { BSKY_DOMAIN } from "~lib/constants";
-import { STORAGE_KEYS } from "~lib/constants";
+import { BSKY_DOMAIN, MESSAGE_NAMES, STORAGE_KEYS } from "~lib/constants";
 import { scrapeListNameFromPage } from "~lib/domHelpers";
 import type { CrawledUserInfo, IService, MessageName } from "~types";
 

--- a/src/style.css
+++ b/src/style.css
@@ -37,7 +37,7 @@
   height: calc(100% + 4px);
   animation: glowing 20s linear infinite;
   opacity: 1;
-  transition: opacity .3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Upgrade `@biomejs/biome` from 1.9.3 to 2.3.13
- Migrate biome.json schema from 1.5.1 to 2.3.13
- Fix lint errors and warnings caused by version upgrade

## Background
The CI environment was using Biome 2.3.13 (via `biomejs/setup-biome@v2` with `version: latest`), while the local development environment was using 1.9.3. This version mismatch caused CI failures with schema incompatibility errors:

```
The configuration schema version does not match the CLI version 2.3.13
Expected: 2.3.13
Found: 1.5.1
```

## Changes

### 1. Biome Version Upgrade
- Updated package.json to use Biome 2.3.13
- Updated package-lock.json accordingly

### 2. Configuration Migration
- Migrated biome.json schema from 1.5.1 to 2.3.13
- Updated `organizeImports` to new `assist.actions.source.organizeImports` format (Biome 2.x structure)
- Disabled `noUnknownAtRules` for Tailwind CSS directives (@tailwind base/components/utilities)

### 3. Code Fixes
- Fixed biome-ignore comment placeholders (`<explanation>` → proper descriptions)
- Auto-fixed formatting issues across 27 files
- Fixed Fragment usage in React components

## Test Plan
- [x] Ran `npm run check` - All checks passed
- [x] Ran `npm run check:ci` - No errors (86 files checked)
- [x] Pre-commit hooks executed successfully

## Related
This PR resolves the CI failure that was blocking #172.