### PR TITLE
docs: Add OAuth (v3.0.0) sign-in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/kawamataryo/sky-follower-bridge/assets/11070996/67bdd228-dc67
 1. On 𝕏 open Your [Following](https://x.com/following), [Followers](https://x.com/followers), or [Blocked](https://x.com/settings/blocked/all) users list, or the Members page of a public List.
 2. Use the `Alt + B` shortcut or click on the toolbar icon to launch the Sky Follower Bridge extension.
 3. Sign in to Bluesky:
-   - **Bluesky (OAuth)** (recommended): Enter your handle and click "Sign in with Bluesky". A browser window will open for secure OAuth login.
+   - **Bluesky (sign in in browser)** (recommended, OAuth): Enter your handle and click "Sign in with Bluesky". A browser window will open for sign-in.
    - **App Password**: Switch to the "App Password" tab and enter your email or handle plus an [app password](https://bsky.app/settings/app-passwords).
 4. Press the `Finding Bluesky Users` btn.
 5. Bluesky users will appear in the Modal.

--- a/docs/de/get-started-for-facebook.md
+++ b/docs/de/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
+**Ab v3.0.0** können Sie sich im Browser anmelden (OAuth, empfohlen) oder mit App Password. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie Anmeldefehler erhalten, lesen Sie bitte den [Fehlerbehebungsleitfaden](/troubleshooting).

--- a/docs/de/get-started-for-facebook.md
+++ b/docs/de/get-started-for-facebook.md
@@ -39,9 +39,9 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ![alt text](/images/instagram-open-extension.png)
 
-### 3. Melden Sie sich bei Bluesky an
+### 3. Bei Bluesky anmelden
 
-Geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
+**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie Anmeldefehler erhalten, lesen Sie bitte den [Fehlerbehebungsleitfaden](/troubleshooting).

--- a/docs/de/get-started-for-instagram.md
+++ b/docs/de/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-Geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
+**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started-for-instagram.md
+++ b/docs/de/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
+**Ab v3.0.0** können Sie sich im Browser anmelden (OAuth, empfohlen) oder mit App Password. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started-for-threads.md
+++ b/docs/de/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-Geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
+**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started-for-threads.md
+++ b/docs/de/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
+**Ab v3.0.0** können Sie sich im Browser anmelden (OAuth, empfohlen) oder mit App Password. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started-for-tiktok.md
+++ b/docs/de/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-Geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
+**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started-for-tiktok.md
+++ b/docs/de/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bei Bluesky anmelden
 
-**Ab v3.0.0** können Sie sich mit OAuth (empfohlen) oder App Password anmelden. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
+**Ab v3.0.0** können Sie sich im Browser anmelden (OAuth, empfohlen) oder mit App Password. Details finden Sie in der [Anleitung Erste Schritte](/de/get-started).
 
 ::: tip
 Wenn Sie auf Anmeldefehler stoßen, lesen Sie bitte den [Fehlerbehebungsleitfaden](/de/troubleshooting).

--- a/docs/de/get-started.md
+++ b/docs/de/get-started.md
@@ -39,11 +39,11 @@ Sky Follower Bridge ist nur für Desktop-Browser verfügbar. Mobile Browser werd
 
 **Ab v3.0.0** können Sie sich auf eine der folgenden Arten anmelden:
 
-- **Bluesky (OAuth)** (empfohlen): Geben Sie Ihren Handle ein und klicken Sie auf „Sign in with Bluesky“. Ein Browserfenster öffnet sich für die sichere OAuth-Anmeldung. Kein App-Passwort erforderlich.
+- **Bluesky (im Browser anmelden)** (empfohlen, OAuth): Geben Sie Ihren Handle ein und klicken Sie auf „Sign in with Bluesky“. Ein Browserfenster öffnet sich zur Anmeldung. Kein App-Passwort erforderlich.
 - **App Password**: Wechseln Sie zum Tab „App Password“ und geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
 
 ::: info Versionshinweis
-Die OAuth-Anmeldung ist ab **v3.0.0** verfügbar. In älteren Versionen ist nur die App-Password-Methode verfügbar.
+Die Anmeldung im Browser (OAuth) ist ab **v3.0.0** verfügbar. In älteren Versionen ist nur die App-Password-Methode verfügbar.
 :::
 
 ::: tip

--- a/docs/de/get-started.md
+++ b/docs/de/get-started.md
@@ -35,6 +35,23 @@ Wir empfehlen die Verwendung der Chrome Web Store-Version, da sie immer auf dem 
 Sky Follower Bridge ist nur für Desktop-Browser verfügbar. Mobile Browser werden nicht unterstützt.
 :::
 
+### 3. Bei Bluesky anmelden
+
+**Ab v3.0.0** können Sie sich auf eine der folgenden Arten anmelden:
+
+- **Bluesky (OAuth)** (empfohlen): Geben Sie Ihren Handle ein und klicken Sie auf „Sign in with Bluesky“. Ein Browserfenster öffnet sich für die sichere OAuth-Anmeldung. Kein App-Passwort erforderlich.
+- **App Password**: Wechseln Sie zum Tab „App Password“ und geben Sie Ihren Bluesky-Handle (oder E-Mail) und [App-Passwort](https://bsky.app/settings/app-passwords) ein.
+
+::: info Versionshinweis
+Die OAuth-Anmeldung ist ab **v3.0.0** verfügbar. In älteren Versionen ist nur die App-Password-Methode verfügbar.
+:::
+
+::: tip
+Bei Anmeldefehlern lesen Sie bitte die [Anleitung zur Fehlerbehebung](/de/troubleshooting).
+:::
+
+![enter-credentials](/images/enter-credentials.png)
+
 ### 4. Suche starten
 
 Klicken Sie auf "Find Bluesky Users", um den Scan zu starten. Die Erweiterung sucht nach passenden Bluesky-Profilen, indem sie die Bluesky-API überprüft.

--- a/docs/de/troubleshooting.md
+++ b/docs/de/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Authentifizierungsfehler
 
-### Anmeldeprobleme
+::: info Mit Bluesky (OAuth) anmelden — ab v3.0.0
+Ab **v3.0.0** können Sie sich per OAuth anmelden, indem Sie den Tab „Bluesky“ wählen, Ihren Handle eingeben und auf „Sign in with Bluesky“ klicken. Ein Browserfenster öffnet sich zur Anmeldung; ein App-Passwort ist nicht erforderlich. Bei Problemen mit OAuth versuchen Sie den Tab „App Password“ (siehe [Anmeldeprobleme](#anmeldeprobleme-app-password-methode) unten).
+:::
+
+### Anmeldeprobleme (App-Password-Methode)
+
+Das Folgende gilt, wenn Sie sich mit dem Tab **App Password** anmelden. Bei **Bluesky (OAuth)** (v3.0.0+) beachten Sie den Hinweis am Anfang dieses Abschnitts.
 
 **Fehlermeldung:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/de/troubleshooting.md
+++ b/docs/de/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Authentifizierungsfehler
 
-::: info Mit Bluesky (OAuth) anmelden — ab v3.0.0
-Ab **v3.0.0** können Sie sich per OAuth anmelden, indem Sie den Tab „Bluesky“ wählen, Ihren Handle eingeben und auf „Sign in with Bluesky“ klicken. Ein Browserfenster öffnet sich zur Anmeldung; ein App-Passwort ist nicht erforderlich. Bei Problemen mit OAuth versuchen Sie den Tab „App Password“ (siehe [Anmeldeprobleme](#anmeldeprobleme-app-password-methode) unten).
+::: info Im Browser anmelden (OAuth) — ab v3.0.0
+Ab **v3.0.0** können Sie sich im Browser anmelden (OAuth), indem Sie den Tab „Bluesky“ wählen, Ihren Handle eingeben und auf „Sign in with Bluesky“ klicken. Ein Browserfenster öffnet sich zur Anmeldung; ein App-Passwort ist nicht erforderlich. Bei Problemen versuchen Sie den Tab „App Password“ (siehe [Anmeldeprobleme](#anmeldeprobleme-app-password-methode) unten).
 :::
 
 ### Anmeldeprobleme (App-Password-Methode)
 
-Das Folgende gilt, wenn Sie sich mit dem Tab **App Password** anmelden. Bei **Bluesky (OAuth)** (v3.0.0+) beachten Sie den Hinweis am Anfang dieses Abschnitts.
+Das Folgende gilt, wenn Sie sich mit dem Tab **App Password** anmelden. Bei **Anmeldung im Browser (OAuth)** (v3.0.0+) beachten Sie den Hinweis am Anfang dieses Abschnitts.
 
 **Fehlermeldung:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/es/get-started-for-facebook.md
+++ b/docs/es/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-Ingresa tu identificador de Bluesky (o correo electrónico) y [contraseña de la aplicación](https://bsky.app/settings/app-passwords).
+**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/troubleshooting).

--- a/docs/es/get-started-for-facebook.md
+++ b/docs/es/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
+**Desde la v3.0.0** puedes iniciar sesión en el navegador (OAuth, recomendado) o con App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/troubleshooting).

--- a/docs/es/get-started-for-instagram.md
+++ b/docs/es/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-Ingresa tu identificador de Bluesky (o correo electrónico) y [contraseña de aplicación](https://bsky.app/settings/app-passwords).
+**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started-for-instagram.md
+++ b/docs/es/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
+**Desde la v3.0.0** puedes iniciar sesión en el navegador (OAuth, recomendado) o con App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started-for-threads.md
+++ b/docs/es/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-Ingresa tu identificador de Bluesky (o correo electrónico) y [contraseña de aplicación](https://bsky.app/settings/app-passwords).
+**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started-for-threads.md
+++ b/docs/es/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
+**Desde la v3.0.0** puedes iniciar sesión en el navegador (OAuth, recomendado) o con App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started-for-tiktok.md
+++ b/docs/es/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-Ingresa tu identificador de Bluesky (o correo electrónico) y [contraseña de aplicación](https://bsky.app/settings/app-passwords).
+**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started-for-tiktok.md
+++ b/docs/es/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-**Desde la v3.0.0** puedes iniciar sesión con OAuth (recomendado) o App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
+**Desde la v3.0.0** puedes iniciar sesión en el navegador (OAuth, recomendado) o con App Password. Consulta la [Guía de inicio](/es/get-started) para más detalles.
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/es/troubleshooting).

--- a/docs/es/get-started.md
+++ b/docs/es/get-started.md
@@ -63,11 +63,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **Desde la v3.0.0** puedes iniciar sesión con cualquiera de estos métodos:
 
-- **Bluesky (OAuth)** (recomendado): Ingresa tu handle y haz clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para el inicio de sesión seguro por OAuth. No se requiere contraseña de aplicación.
+- **Bluesky (iniciar sesión en el navegador)** (recomendado, OAuth): Ingresa tu handle y haz clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para iniciar sesión. No se requiere contraseña de aplicación.
 - **App Password**: Cambia a la pestaña "App Password" e ingresa tu handle de Bluesky (o correo electrónico) y [Contraseña de la aplicación](https://bsky.app/settings/app-passwords).
 
 ::: info Nota de versión
-El inicio de sesión por OAuth está disponible desde la **v3.0.0**. En versiones anteriores solo está disponible el método App Password.
+El inicio de sesión en el navegador (OAuth) está disponible desde la **v3.0.0**. En versiones anteriores solo está disponible el método App Password.
 :::
 
 ::: tip

--- a/docs/es/get-started.md
+++ b/docs/es/get-started.md
@@ -61,7 +61,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Inicia sesión en Bluesky
 
-Ingresa tu identificador de Bluesky (o correo electrónico) y [Contraseña de la aplicación](https://bsky.app/settings/app-passwords).
+**Desde la v3.0.0** puedes iniciar sesión con cualquiera de estos métodos:
+
+- **Bluesky (OAuth)** (recomendado): Ingresa tu handle y haz clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para el inicio de sesión seguro por OAuth. No se requiere contraseña de aplicación.
+- **App Password**: Cambia a la pestaña "App Password" e ingresa tu handle de Bluesky (o correo electrónico) y [Contraseña de la aplicación](https://bsky.app/settings/app-passwords).
+
+::: info Nota de versión
+El inicio de sesión por OAuth está disponible desde la **v3.0.0**. En versiones anteriores solo está disponible el método App Password.
+:::
 
 ::: tip
 Si encuentras errores de inicio de sesión, consulta la [Guía de solución de problemas](/troubleshooting).

--- a/docs/es/troubleshooting.md
+++ b/docs/es/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Errores de autenticación
 
-### Problemas de inicio de sesión
+::: info Iniciar sesión con Bluesky (OAuth) — desde la v3.0.0
+Desde la **v3.0.0** puedes iniciar sesión por OAuth eligiendo la pestaña "Bluesky", ingresando tu handle y haciendo clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para iniciar sesión; no se requiere contraseña de aplicación. Si tienes problemas con OAuth, prueba la pestaña "App Password" (ver [Problemas de inicio de sesión](#problemas-de-inicio-de-sesión-método-app-password) abajo).
+:::
+
+### Problemas de inicio de sesión (método App Password)
+
+Lo siguiente aplica cuando inicias sesión con la pestaña **App Password**. Si usas **Bluesky (OAuth)** (v3.0.0+), consulta la nota al inicio de esta sección.
 
 **Mensaje de error:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/es/troubleshooting.md
+++ b/docs/es/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Errores de autenticación
 
-::: info Iniciar sesión con Bluesky (OAuth) — desde la v3.0.0
-Desde la **v3.0.0** puedes iniciar sesión por OAuth eligiendo la pestaña "Bluesky", ingresando tu handle y haciendo clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para iniciar sesión; no se requiere contraseña de aplicación. Si tienes problemas con OAuth, prueba la pestaña "App Password" (ver [Problemas de inicio de sesión](#problemas-de-inicio-de-sesión-método-app-password) abajo).
+::: info Iniciar sesión en el navegador (OAuth) — desde la v3.0.0
+Desde la **v3.0.0** puedes iniciar sesión en el navegador (OAuth) eligiendo la pestaña "Bluesky", ingresando tu handle y haciendo clic en "Sign in with Bluesky". Se abrirá una ventana del navegador para iniciar sesión; no se requiere contraseña de aplicación. Si tienes problemas, prueba la pestaña "App Password" (ver [Problemas de inicio de sesión](#problemas-de-inicio-de-sesión-método-app-password) abajo).
 :::
 
 ### Problemas de inicio de sesión (método App Password)
 
-Lo siguiente aplica cuando inicias sesión con la pestaña **App Password**. Si usas **Bluesky (OAuth)** (v3.0.0+), consulta la nota al inicio de esta sección.
+Lo siguiente aplica cuando inicias sesión con la pestaña **App Password**. Si usas **iniciar sesión en el navegador (OAuth)** (v3.0.0+), consulta la nota al inicio de esta sección.
 
 **Mensaje de error:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/fr/get-started-for-facebook.md
+++ b/docs/fr/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
+**À partir de la v3.0.0**, vous pouvez vous connecter dans le navigateur (OAuth, recommandé) ou avec App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/troubleshooting).

--- a/docs/fr/get-started-for-facebook.md
+++ b/docs/fr/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-Entrez votre identifiant Bluesky (ou email) et [mot de passe de l'application](https://bsky.app/settings/app-passwords).
+**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/troubleshooting).

--- a/docs/fr/get-started-for-instagram.md
+++ b/docs/fr/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-Entrez votre identifiant Bluesky (ou email) et [mot de passe d'application](https://bsky.app/settings/app-passwords).
+**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started-for-instagram.md
+++ b/docs/fr/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
+**À partir de la v3.0.0**, vous pouvez vous connecter dans le navigateur (OAuth, recommandé) ou avec App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started-for-threads.md
+++ b/docs/fr/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
+**À partir de la v3.0.0**, vous pouvez vous connecter dans le navigateur (OAuth, recommandé) ou avec App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started-for-threads.md
+++ b/docs/fr/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-Entrez votre identifiant Bluesky (ou email) et [mot de passe d'application](https://bsky.app/settings/app-passwords).
+**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started-for-tiktok.md
+++ b/docs/fr/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-Entrez votre identifiant Bluesky (ou email) et [mot de passe d'application](https://bsky.app/settings/app-passwords).
+**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started-for-tiktok.md
+++ b/docs/fr/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-**À partir de la v3.0.0**, vous pouvez vous connecter avec OAuth (recommandé) ou App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
+**À partir de la v3.0.0**, vous pouvez vous connecter dans le navigateur (OAuth, recommandé) ou avec App Password. Consultez le [Guide de démarrage](/fr/get-started) pour les détails.
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/fr/troubleshooting).

--- a/docs/fr/get-started.md
+++ b/docs/fr/get-started.md
@@ -63,11 +63,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **À partir de la v3.0.0**, vous pouvez vous connecter de l'une des manières suivantes :
 
-- **Bluesky (OAuth)** (recommandé) : Saisissez votre handle et cliquez sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour une connexion sécurisée par OAuth. Aucun mot de passe d'application n'est requis.
+- **Bluesky (connexion dans le navigateur)** (recommandé, OAuth) : Saisissez votre handle et cliquez sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour la connexion. Aucun mot de passe d'application n'est requis.
 - **App Password** : Passez à l'onglet « App Password » et saisissez votre handle Bluesky (ou e-mail) et [App password](https://bsky.app/settings/app-passwords).
 
 ::: info Note de version
-La connexion par OAuth est disponible à partir de la **v3.0.0**. Dans les versions antérieures, seul le mode App Password est disponible.
+La connexion dans le navigateur (OAuth) est disponible à partir de la **v3.0.0**. Dans les versions antérieures, seul le mode App Password est disponible.
 :::
 
 ::: tip

--- a/docs/fr/get-started.md
+++ b/docs/fr/get-started.md
@@ -61,7 +61,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Connectez-vous à Bluesky
 
-Entrez votre identifiant Bluesky (ou email) et [App password](https://bsky.app/settings/app-passwords).
+**À partir de la v3.0.0**, vous pouvez vous connecter de l'une des manières suivantes :
+
+- **Bluesky (OAuth)** (recommandé) : Saisissez votre handle et cliquez sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour une connexion sécurisée par OAuth. Aucun mot de passe d'application n'est requis.
+- **App Password** : Passez à l'onglet « App Password » et saisissez votre handle Bluesky (ou e-mail) et [App password](https://bsky.app/settings/app-passwords).
+
+::: info Note de version
+La connexion par OAuth est disponible à partir de la **v3.0.0**. Dans les versions antérieures, seul le mode App Password est disponible.
+:::
 
 ::: tip
 Si vous rencontrez des erreurs de connexion, veuillez consulter le [Guide de dépannage](/troubleshooting).

--- a/docs/fr/troubleshooting.md
+++ b/docs/fr/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Erreurs d'authentification
 
-### Problèmes de connexion
+::: info Connexion avec Bluesky (OAuth) — à partir de la v3.0.0
+À partir de la **v3.0.0**, vous pouvez vous connecter via OAuth en choisissant l'onglet « Bluesky », en saisissant votre handle et en cliquant sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour la connexion ; aucun mot de passe d'application n'est requis. En cas de problème avec OAuth, essayez l'onglet « App Password » (voir [Problèmes de connexion](#problèmes-de-connexion-méthode-app-password) ci-dessous).
+:::
+
+### Problèmes de connexion (méthode App Password)
+
+Ce qui suit s'applique lorsque vous vous connectez avec l'onglet **App Password**. Si vous utilisez **Bluesky (OAuth)** (v3.0.0+), reportez-vous à la note en tête de cette section.
 
 **Message d'erreur :**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/fr/troubleshooting.md
+++ b/docs/fr/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Erreurs d'authentification
 
-::: info Connexion avec Bluesky (OAuth) — à partir de la v3.0.0
-À partir de la **v3.0.0**, vous pouvez vous connecter via OAuth en choisissant l'onglet « Bluesky », en saisissant votre handle et en cliquant sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour la connexion ; aucun mot de passe d'application n'est requis. En cas de problème avec OAuth, essayez l'onglet « App Password » (voir [Problèmes de connexion](#problèmes-de-connexion-méthode-app-password) ci-dessous).
+::: info Connexion dans le navigateur (OAuth) — à partir de la v3.0.0
+À partir de la **v3.0.0**, vous pouvez vous connecter dans le navigateur (OAuth) en choisissant l'onglet « Bluesky », en saisissant votre handle et en cliquant sur « Sign in with Bluesky ». Une fenêtre du navigateur s'ouvrira pour la connexion ; aucun mot de passe d'application n'est requis. En cas de problème, essayez l'onglet « App Password » (voir [Problèmes de connexion](#problèmes-de-connexion-méthode-app-password) ci-dessous).
 :::
 
 ### Problèmes de connexion (méthode App Password)
 
-Ce qui suit s'applique lorsque vous vous connectez avec l'onglet **App Password**. Si vous utilisez **Bluesky (OAuth)** (v3.0.0+), reportez-vous à la note en tête de cette section.
+Ce qui suit s'applique lorsque vous vous connectez avec l'onglet **App Password**. Si vous utilisez **connexion dans le navigateur (OAuth)** (v3.0.0+), reportez-vous à la note en tête de cette section.
 
 **Message d'erreur :**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/get-started-for-facebook.md
+++ b/docs/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
+**From v3.0.0** you can sign in in browser (OAuth, recommended) or with App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-facebook.md
+++ b/docs/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-Enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-instagram.md
+++ b/docs/get-started-for-instagram.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-Enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-instagram.md
+++ b/docs/get-started-for-instagram.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
+**From v3.0.0** you can sign in in browser (OAuth, recommended) or with App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-threads.md
+++ b/docs/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-Enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-threads.md
+++ b/docs/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
+**From v3.0.0** you can sign in in browser (OAuth, recommended) or with App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-tiktok.md
+++ b/docs/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-Enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started-for-tiktok.md
+++ b/docs/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-**From v3.0.0** you can sign in with OAuth (recommended) or App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
+**From v3.0.0** you can sign in in browser (OAuth, recommended) or with App Password. See the [Getting Started](/get-started#_3-sign-in-to-bluesky) guide for details.
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -62,7 +62,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Sign in to Bluesky
 
-Enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+**From v3.0.0**, you can sign in with either of the following methods:
+
+- **Bluesky (OAuth)** (recommended): Enter your handle and click "Sign in with Bluesky". A browser window will open for secure OAuth login. No app password is required.
+- **App Password**: Switch to the "App Password" tab and enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
+
+::: info Version note
+OAuth sign-in is available from **v3.0.0**. If you are on an older version, only the App Password method is available.
+:::
 
 ::: tip
 If you encounter login errors, please refer to the [Troubleshooting Guide](/troubleshooting).

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -64,11 +64,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **From v3.0.0**, you can sign in with either of the following methods:
 
-- **Bluesky (OAuth)** (recommended): Enter your handle and click "Sign in with Bluesky". A browser window will open for secure OAuth login. No app password is required.
+- **Bluesky (sign in in browser)** (recommended, OAuth): Enter your handle and click "Sign in with Bluesky". A browser window will open for sign-in; no app password is required.
 - **App Password**: Switch to the "App Password" tab and enter your Bluesky handle (or email) and [App password](https://bsky.app/settings/app-passwords).
 
 ::: info Version note
-OAuth sign-in is available from **v3.0.0**. If you are on an older version, only the App Password method is available.
+Sign-in in browser (OAuth) is available from **v3.0.0**. If you are on an older version, only the App Password method is available.
 :::
 
 ::: tip

--- a/docs/it/get-started-for-facebook.md
+++ b/docs/it/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
+**Dalla v3.0.0** puoi accedere nel browser (OAuth, consigliato) o con App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se incontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/troubleshooting).

--- a/docs/it/get-started-for-facebook.md
+++ b/docs/it/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-Inserisci il tuo handle di Bluesky (o email) e [password dell'app](https://bsky.app/settings/app-passwords).
+**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se incontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/troubleshooting).

--- a/docs/it/get-started-for-instagram.md
+++ b/docs/it/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-Inserisci il tuo handle Bluesky (o email) e [password dell'applicazione](https://bsky.app/settings/app-passwords).
+**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se riscontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started-for-instagram.md
+++ b/docs/it/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
+**Dalla v3.0.0** puoi accedere nel browser (OAuth, consigliato) o con App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se riscontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started-for-threads.md
+++ b/docs/it/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
+**Dalla v3.0.0** puoi accedere nel browser (OAuth, consigliato) o con App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se riscontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started-for-threads.md
+++ b/docs/it/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-Inserisci il tuo handle Bluesky (o email) e [password dell'applicazione](https://bsky.app/settings/app-passwords).
+**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se riscontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started-for-tiktok.md
+++ b/docs/it/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-Inserisci il tuo handle di Bluesky (o email) e [password dell'app](https://bsky.app/settings/app-passwords).
+**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se incontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started-for-tiktok.md
+++ b/docs/it/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-**Dalla v3.0.0** puoi accedere con OAuth (consigliato) o App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
+**Dalla v3.0.0** puoi accedere nel browser (OAuth, consigliato) o con App Password. Consulta la [Guida introduttiva](/it/get-started) per i dettagli.
 
 ::: tip
 Se incontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/it/troubleshooting).

--- a/docs/it/get-started.md
+++ b/docs/it/get-started.md
@@ -61,7 +61,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Accedi a Bluesky
 
-Inserisci il tuo handle di Bluesky (o email) e [App password](https://bsky.app/settings/app-passwords).
+**Dalla v3.0.0** puoi accedere con uno dei seguenti metodi:
+
+- **Bluesky (OAuth)** (consigliato): Inserisci il tuo handle e clicca su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso sicuro tramite OAuth. Non è necessaria la password dell'app.
+- **App Password**: Passa alla scheda "App Password" e inserisci il tuo handle Bluesky (o email) e [App password](https://bsky.app/settings/app-passwords).
+
+::: info Nota sulla versione
+L'accesso tramite OAuth è disponibile dalla **v3.0.0**. Nelle versioni precedenti è disponibile solo il metodo App Password.
+:::
 
 ::: tip
 Se incontri errori di accesso, consulta la [Guida alla risoluzione dei problemi](/troubleshooting).

--- a/docs/it/get-started.md
+++ b/docs/it/get-started.md
@@ -63,11 +63,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **Dalla v3.0.0** puoi accedere con uno dei seguenti metodi:
 
-- **Bluesky (OAuth)** (consigliato): Inserisci il tuo handle e clicca su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso sicuro tramite OAuth. Non è necessaria la password dell'app.
+- **Bluesky (accedi nel browser)** (consigliato, OAuth): Inserisci il tuo handle e clicca su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso. Non è necessaria la password dell'app.
 - **App Password**: Passa alla scheda "App Password" e inserisci il tuo handle Bluesky (o email) e [App password](https://bsky.app/settings/app-passwords).
 
 ::: info Nota sulla versione
-L'accesso tramite OAuth è disponibile dalla **v3.0.0**. Nelle versioni precedenti è disponibile solo il metodo App Password.
+L'accesso nel browser (OAuth) è disponibile dalla **v3.0.0**. Nelle versioni precedenti è disponibile solo il metodo App Password.
 :::
 
 ::: tip

--- a/docs/it/troubleshooting.md
+++ b/docs/it/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Errori di autenticazione
 
-### Problemi di accesso
+::: info Accedi con Bluesky (OAuth) — dalla v3.0.0
+Dalla **v3.0.0** puoi accedere tramite OAuth scegliendo la scheda "Bluesky", inserendo il tuo handle e cliccando su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso; non è necessaria la password dell'app. In caso di problemi con OAuth, prova la scheda "App Password" (vedi [Problemi di accesso](#problemi-di-accesso-metodo-app-password) sotto).
+:::
+
+### Problemi di accesso (metodo App Password)
+
+Quanto segue si applica quando accedi usando la scheda **App Password**. Se usi **Bluesky (OAuth)** (v3.0.0+), consulta la nota in cima a questa sezione.
 
 **Messaggio di errore:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/it/troubleshooting.md
+++ b/docs/it/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Errori di autenticazione
 
-::: info Accedi con Bluesky (OAuth) — dalla v3.0.0
-Dalla **v3.0.0** puoi accedere tramite OAuth scegliendo la scheda "Bluesky", inserendo il tuo handle e cliccando su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso; non è necessaria la password dell'app. In caso di problemi con OAuth, prova la scheda "App Password" (vedi [Problemi di accesso](#problemi-di-accesso-metodo-app-password) sotto).
+::: info Accedi nel browser (OAuth) — dalla v3.0.0
+Dalla **v3.0.0** puoi accedere nel browser (OAuth) scegliendo la scheda "Bluesky", inserendo il tuo handle e cliccando su "Sign in with Bluesky". Si aprirà una finestra del browser per l'accesso; non è necessaria la password dell'app. In caso di problemi, prova la scheda "App Password" (vedi [Problemi di accesso](#problemi-di-accesso-metodo-app-password) sotto).
 :::
 
 ### Problemi di accesso (metodo App Password)
 
-Quanto segue si applica quando accedi usando la scheda **App Password**. Se usi **Bluesky (OAuth)** (v3.0.0+), consulta la nota in cima a questa sezione.
+Quanto segue si applica quando accedi usando la scheda **App Password**. Se usi **accedi nel browser (OAuth)** (v3.0.0+), consulta la nota in cima a questa sezione.
 
 **Messaggio di errore:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/ja/get-started-for-facebook.md
+++ b/docs/ja/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-Blueskyのハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力します。
+**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-facebook.md
+++ b/docs/ja/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
+**v3.0.0 以降**はブラウザでログイン（OAuth、推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-instagram.md
+++ b/docs/ja/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
+**v3.0.0 以降**はブラウザでログイン（OAuth、推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-instagram.md
+++ b/docs/ja/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-あなたのBlueskyハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力してください。
+**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-threads.md
+++ b/docs/ja/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
+**v3.0.0 以降**はブラウザでログイン（OAuth、推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-threads.md
+++ b/docs/ja/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-Blueskyのハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力します。
+**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-tiktok.md
+++ b/docs/ja/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
+**v3.0.0 以降**はブラウザでログイン（OAuth、推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started-for-tiktok.md
+++ b/docs/ja/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-Blueskyのハンドル（またはメールアドレス）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力します。
+**v3.0.0 以降**は OAuth（推奨）または App Password でサインインできます。詳しくは[はじめに](/ja/get-started)をご覧ください。
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/get-started.md
+++ b/docs/ja/get-started.md
@@ -63,11 +63,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **v3.0.0 以降**、次のいずれかの方法でサインインできます。
 
-- **Bluesky（OAuth）**（推奨）: ハンドルを入力し「Sign in with Bluesky」をクリック。ブラウザが開き、安全な OAuth ログインが行われます。アプリパスワードは不要です。
+- **Bluesky（ブラウザでログイン）**（推奨、OAuth）: ハンドルを入力し「Sign in with Bluesky」をクリック。ブラウザが開いてサインインします。アプリパスワードは不要です。
 - **App Password**: 「App Password」タブに切り替え、Bluesky のハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力してください。
 
 ::: info バージョンについて
-OAuth でのサインインは **v3.0.0 以降**で利用できます。それ以前のバージョンでは App Password のみ利用可能です。
+ブラウザでログイン（OAuth）は **v3.0.0 以降**で利用できます。それ以前のバージョンでは App Password のみ利用可能です。
 :::
 
 ::: tip

--- a/docs/ja/get-started.md
+++ b/docs/ja/get-started.md
@@ -61,7 +61,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Blueskyにサインイン
 
-あなたのBlueskyハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力してください。
+**v3.0.0 以降**、次のいずれかの方法でサインインできます。
+
+- **Bluesky（OAuth）**（推奨）: ハンドルを入力し「Sign in with Bluesky」をクリック。ブラウザが開き、安全な OAuth ログインが行われます。アプリパスワードは不要です。
+- **App Password**: 「App Password」タブに切り替え、Bluesky のハンドル（またはメール）と[アプリパスワード](https://bsky.app/settings/app-passwords)を入力してください。
+
+::: info バージョンについて
+OAuth でのサインインは **v3.0.0 以降**で利用できます。それ以前のバージョンでは App Password のみ利用可能です。
+:::
 
 ::: tip
 ログインエラーが発生した場合は、[トラブルシューティングガイド](/ja/troubleshooting)を参照してください。

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## 認証エラー
 
-### ログインの問題
+::: info Bluesky（OAuth）でサインイン — v3.0.0 以降
+**v3.0.0 以降**では、「Bluesky」タブを選び、ハンドルを入力して「Sign in with Bluesky」をクリックすると OAuth でサインインできます。ブラウザが開いてログインするため、アプリパスワードは不要です。OAuth で問題がある場合は「App Password」タブ（下記[ログインの問題](#ログインの問題-app-password-の場合)を参照）を試してください。
+:::
+
+### ログインの問題（App Password の場合）
+
+以下は**App Password**タブでサインインする場合の内容です。**Bluesky（OAuth）**（v3.0.0 以降）を使う場合は、上記の説明を参照してください。
 
 **エラーメッセージ:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## 認証エラー
 
-::: info Bluesky（OAuth）でサインイン — v3.0.0 以降
-**v3.0.0 以降**では、「Bluesky」タブを選び、ハンドルを入力して「Sign in with Bluesky」をクリックすると OAuth でサインインできます。ブラウザが開いてログインするため、アプリパスワードは不要です。OAuth で問題がある場合は「App Password」タブ（下記[ログインの問題](#ログインの問題-app-password-の場合)を参照）を試してください。
+::: info ブラウザでログイン（OAuth）— v3.0.0 以降
+**v3.0.0 以降**では、「Bluesky」タブを選び、ハンドルを入力して「Sign in with Bluesky」をクリックすると、ブラウザでサインインできます（OAuth）。アプリパスワードは不要です。問題がある場合は「App Password」タブ（下記[ログインの問題](#ログインの問題-app-password-の場合)を参照）を試してください。
 :::
 
 ### ログインの問題（App Password の場合）
 
-以下は**App Password**タブでサインインする場合の内容です。**Bluesky（OAuth）**（v3.0.0 以降）を使う場合は、上記の説明を参照してください。
+以下は**App Password**タブでサインインする場合の内容です。**ブラウザでログイン（OAuth）**（v3.0.0 以降）を使う場合は、上記の説明を参照してください。
 
 **エラーメッセージ:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/ko/get-started-for-facebook.md
+++ b/docs/ko/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bluesky 로그인
 
-**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
+**v3.0.0부터** 브라우저에서 로그인(OAuth, 권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생하면 [문제 해결 가이드](/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started-for-facebook.md
+++ b/docs/ko/get-started-for-facebook.md
@@ -39,9 +39,9 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ![alt text](/images/instagram-open-extension.png)
 
-### 3. Bluesky에 로그인
+### 3. Bluesky 로그인
 
-Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
+**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생하면 [문제 해결 가이드](/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started-for-instagram.md
+++ b/docs/ko/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bluesky 로그인
 
-Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
+**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생한 경우 [문제 해결 가이드](/ko/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started-for-instagram.md
+++ b/docs/ko/get-started-for-instagram.md
@@ -45,7 +45,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bluesky 로그인
 
-**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
+**v3.0.0부터** 브라우저에서 로그인(OAuth, 권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생한 경우 [문제 해결 가이드](/ko/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started-for-tiktok.md
+++ b/docs/ko/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bluesky 로그인
 
-**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
+**v3.0.0부터** 브라우저에서 로그인(OAuth, 권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생하면, [문제 해결 가이드](/ko/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started-for-tiktok.md
+++ b/docs/ko/get-started-for-tiktok.md
@@ -45,9 +45,9 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ![alt text](/images/instagram-open-extension.png)
 
-### 3. Bluesky에 로그인
+### 3. Bluesky 로그인
 
-Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
+**v3.0.0부터** OAuth(권장) 또는 App Password로 로그인할 수 있습니다. 자세한 내용은 [시작하기](/ko/get-started)를 참조하세요.
 
 ::: tip
 로그인 오류가 발생하면, [문제 해결 가이드](/ko/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started.md
+++ b/docs/ko/get-started.md
@@ -60,7 +60,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Bluesky 로그인
 
-Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
+**v3.0.0부터** 다음 방법 중 하나로 로그인할 수 있습니다.
+
+- **Bluesky(OAuth)**(권장): 핸들을 입력하고 "Sign in with Bluesky"를 클릭하세요. 브라우저 창이 열려 안전한 OAuth 로그인이 진행됩니다. 앱 비밀번호는 필요하지 않습니다.
+- **App Password**: "App Password" 탭으로 전환한 후 Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
+
+::: info 버전 안내
+OAuth 로그인은 **v3.0.0**부터 사용할 수 있습니다. 이전 버전에서는 App Password 방식만 사용 가능합니다.
+:::
 
 ::: tip
 로그인 오류가 발생한 경우 [문제 해결 가이드](/ko/troubleshooting)를 참조하세요.

--- a/docs/ko/get-started.md
+++ b/docs/ko/get-started.md
@@ -62,11 +62,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **v3.0.0부터** 다음 방법 중 하나로 로그인할 수 있습니다.
 
-- **Bluesky(OAuth)**(권장): 핸들을 입력하고 "Sign in with Bluesky"를 클릭하세요. 브라우저 창이 열려 안전한 OAuth 로그인이 진행됩니다. 앱 비밀번호는 필요하지 않습니다.
+- **Bluesky(브라우저에서 로그인)**(권장, OAuth): 핸들을 입력하고 "Sign in with Bluesky"를 클릭하세요. 브라우저 창이 열려 로그인합니다. 앱 비밀번호는 필요하지 않습니다.
 - **App Password**: "App Password" 탭으로 전환한 후 Bluesky 핸들(또는 이메일)과 [앱 비밀번호](https://bsky.app/settings/app-passwords)를 입력하세요.
 
 ::: info 버전 안내
-OAuth 로그인은 **v3.0.0**부터 사용할 수 있습니다. 이전 버전에서는 App Password 방식만 사용 가능합니다.
+브라우저에서 로그인(OAuth)은 **v3.0.0**부터 사용할 수 있습니다. 이전 버전에서는 App Password 방식만 사용 가능합니다.
 :::
 
 ::: tip

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## 인증 오류
 
-::: info Bluesky(OAuth)로 로그인 — v3.0.0부터
-**v3.0.0**부터 "Bluesky" 탭을 선택하고 핸들을 입력한 뒤 "Sign in with Bluesky"를 클릭하면 OAuth로 로그인할 수 있습니다. 브라우저 창이 열려 로그인하며 앱 비밀번호는 필요하지 않습니다. OAuth에 문제가 있으면 "App Password" 탭(아래 [로그인 문제](#로그인-문제-app-password-방식) 참조)을 사용해 보세요.
+::: info 브라우저에서 로그인(OAuth) — v3.0.0부터
+**v3.0.0**부터 "Bluesky" 탭을 선택하고 핸들을 입력한 뒤 "Sign in with Bluesky"를 클릭하면 브라우저에서 로그인할 수 있습니다(OAuth). 앱 비밀번호는 필요하지 않습니다. 문제가 있으면 "App Password" 탭(아래 [로그인 문제](#로그인-문제-app-password-방식) 참조)을 사용해 보세요.
 :::
 
 ### 로그인 문제 (App Password 방식)
 
-아래 내용은 **App Password** 탭으로 로그인할 때 해당합니다. **Bluesky(OAuth)**(v3.0.0+)를 사용하는 경우 본 섹션 상단의 안내를 참조하세요.
+아래 내용은 **App Password** 탭으로 로그인할 때 해당합니다. **브라우저에서 로그인(OAuth)**(v3.0.0+)를 사용하는 경우 본 섹션 상단의 안내를 참조하세요.
 
 **오류 메시지:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## 인증 오류
 
-### 로그인 문제
+::: info Bluesky(OAuth)로 로그인 — v3.0.0부터
+**v3.0.0**부터 "Bluesky" 탭을 선택하고 핸들을 입력한 뒤 "Sign in with Bluesky"를 클릭하면 OAuth로 로그인할 수 있습니다. 브라우저 창이 열려 로그인하며 앱 비밀번호는 필요하지 않습니다. OAuth에 문제가 있으면 "App Password" 탭(아래 [로그인 문제](#로그인-문제-app-password-방식) 참조)을 사용해 보세요.
+:::
+
+### 로그인 문제 (App Password 방식)
+
+아래 내용은 **App Password** 탭으로 로그인할 때 해당합니다. **Bluesky(OAuth)**(v3.0.0+)를 사용하는 경우 본 섹션 상단의 안내를 참조하세요.
 
 **오류 메시지:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/pt/get-started-for-facebook.md
+++ b/docs/pt/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
+**A partir da v3.0.0** você pode entrar no navegador (OAuth, recomendado) ou com App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/troubleshooting).

--- a/docs/pt/get-started-for-facebook.md
+++ b/docs/pt/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-Digite seu identificador Bluesky (ou email) e [senha do aplicativo](https://bsky.app/settings/app-passwords).
+**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/troubleshooting).

--- a/docs/pt/get-started-for-instagram.md
+++ b/docs/pt/get-started-for-instagram.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-Digite seu identificador do Bluesky (ou e-mail) e [App password](https://bsky.app/settings/app-passwords).
+**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/pt/troubleshooting).

--- a/docs/pt/get-started-for-instagram.md
+++ b/docs/pt/get-started-for-instagram.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
+**A partir da v3.0.0** você pode entrar no navegador (OAuth, recomendado) ou com App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/pt/troubleshooting).

--- a/docs/pt/get-started-for-threads.md
+++ b/docs/pt/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-Digite seu identificador do Bluesky (ou e-mail) e [App password](https://bsky.app/settings/app-passwords).
+**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/pt/troubleshooting).

--- a/docs/pt/get-started-for-threads.md
+++ b/docs/pt/get-started-for-threads.md
@@ -50,7 +50,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
+**A partir da v3.0.0** você pode entrar no navegador (OAuth, recomendado) ou com App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/pt/troubleshooting).

--- a/docs/pt/get-started-for-tiktok.md
+++ b/docs/pt/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
+**A partir da v3.0.0** você pode entrar no navegador (OAuth, recomendado) ou com App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de solução de problemas](/pt/troubleshooting).

--- a/docs/pt/get-started-for-tiktok.md
+++ b/docs/pt/get-started-for-tiktok.md
@@ -47,7 +47,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-Insira seu identificador do Bluesky (ou email) e [senha do aplicativo](https://bsky.app/settings/app-passwords).
+**A partir da v3.0.0** você pode entrar com OAuth (recomendado) ou App Password. Consulte o [Guia de primeiros passos](/pt/get-started) para detalhes.
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de solução de problemas](/pt/troubleshooting).

--- a/docs/pt/get-started.md
+++ b/docs/pt/get-started.md
@@ -64,11 +64,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **A partir da v3.0.0**, você pode entrar com um dos métodos abaixo:
 
-- **Bluesky (OAuth)** (recomendado): Digite seu handle e clique em "Sign in with Bluesky". Uma janela do navegador será aberta para login seguro via OAuth. Não é necessária senha de app.
+- **Bluesky (entrar no navegador)** (recomendado, OAuth): Digite seu handle e clique em "Sign in with Bluesky". Uma janela do navegador será aberta para login. Não é necessária senha de app.
 - **App Password**: Mude para a aba "App Password" e digite seu identificador Bluesky (ou e-mail) e [App password](https://bsky.app/settings/app-passwords).
 
 ::: info Nota de versão
-O login via OAuth está disponível a partir da **v3.0.0**. Em versões anteriores, apenas o método App Password está disponível.
+Login no navegador (OAuth) está disponível a partir da **v3.0.0**. Em versões anteriores, apenas o método App Password está disponível.
 :::
 
 ::: tip

--- a/docs/pt/get-started.md
+++ b/docs/pt/get-started.md
@@ -62,7 +62,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. Faça login no Bluesky
 
-Digite seu identificador do Bluesky (ou e-mail) e [App password](https://bsky.app/settings/app-passwords).
+**A partir da v3.0.0**, você pode entrar com um dos métodos abaixo:
+
+- **Bluesky (OAuth)** (recomendado): Digite seu handle e clique em "Sign in with Bluesky". Uma janela do navegador será aberta para login seguro via OAuth. Não é necessária senha de app.
+- **App Password**: Mude para a aba "App Password" e digite seu identificador Bluesky (ou e-mail) e [App password](https://bsky.app/settings/app-passwords).
+
+::: info Nota de versão
+O login via OAuth está disponível a partir da **v3.0.0**. Em versões anteriores, apenas o método App Password está disponível.
+:::
 
 ::: tip
 Se você encontrar erros de login, consulte o [Guia de Solução de Problemas](/troubleshooting).

--- a/docs/pt/troubleshooting.md
+++ b/docs/pt/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Erros de Autenticação
 
-### Problemas de Login
+::: info Entrar com Bluesky (OAuth) — a partir da v3.0.0
+A partir da **v3.0.0**, você pode entrar via OAuth escolhendo a aba "Bluesky", digitando seu handle e clicando em "Sign in with Bluesky". Uma janela do navegador será aberta para login; não é necessária senha de app. Se tiver problemas com OAuth, tente a aba "App Password" (veja [Problemas de Login](#problemas-de-login-método-app-password) abaixo).
+:::
+
+### Problemas de Login (método App Password)
+
+O seguinte aplica-se quando você entra usando a aba **App Password**. Se usar **Bluesky (OAuth)** (v3.0.0+), consulte a nota no topo desta seção.
 
 **Mensagem de Erro:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/pt/troubleshooting.md
+++ b/docs/pt/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Erros de Autenticação
 
-::: info Entrar com Bluesky (OAuth) — a partir da v3.0.0
-A partir da **v3.0.0**, você pode entrar via OAuth escolhendo a aba "Bluesky", digitando seu handle e clicando em "Sign in with Bluesky". Uma janela do navegador será aberta para login; não é necessária senha de app. Se tiver problemas com OAuth, tente a aba "App Password" (veja [Problemas de Login](#problemas-de-login-método-app-password) abaixo).
+::: info Entrar no navegador (OAuth) — a partir da v3.0.0
+A partir da **v3.0.0**, você pode entrar no navegador (OAuth) escolhendo a aba "Bluesky", digitando seu handle e clicando em "Sign in with Bluesky". Uma janela do navegador será aberta para login; não é necessária senha de app. Se tiver problemas, tente a aba "App Password" (veja [Problemas de Login](#problemas-de-login-método-app-password) abaixo).
 :::
 
 ### Problemas de Login (método App Password)
 
-O seguinte aplica-se quando você entra usando a aba **App Password**. Se usar **Bluesky (OAuth)** (v3.0.0+), consulte a nota no topo desta seção.
+O seguinte aplica-se quando você entra usando a aba **App Password**. Se usar **entrar no navegador (OAuth)** (v3.0.0+), consulte a nota no topo desta seção.
 
 **Mensagem de Erro:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Authentication Errors
 
-::: info Sign in with Bluesky (OAuth) — from v3.0.0
-From **v3.0.0**, you can sign in via OAuth by choosing the "Bluesky" tab, entering your handle, and clicking "Sign in with Bluesky". A browser window opens for login; no app password is needed. If you have trouble with OAuth, try the "App Password" tab (see [Login Issues](#login-issues) below).
+::: info Sign in in browser (OAuth) — from v3.0.0
+From **v3.0.0**, you can sign in in your browser (OAuth) by choosing the "Bluesky" tab, entering your handle, and clicking "Sign in with Bluesky". A browser window opens for login; no app password is needed. If you have trouble, try the "App Password" tab (see [Login Issues](#login-issues-app-password-method) below).
 :::
 
 ### Login Issues (App Password method)
 
-The following applies when you sign in using the **App Password** tab. If you use **Bluesky (OAuth)** (v3.0.0+), see the note at the top of this section.
+The following applies when you sign in using the **App Password** tab. If you use **sign in in browser (OAuth)** (v3.0.0+), see the note at the top of this section.
 
 **Error Message:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## Authentication Errors
 
-### Login Issues
+::: info Sign in with Bluesky (OAuth) — from v3.0.0
+From **v3.0.0**, you can sign in via OAuth by choosing the "Bluesky" tab, entering your handle, and clicking "Sign in with Bluesky". A browser window opens for login; no app password is needed. If you have trouble with OAuth, try the "App Password" tab (see [Login Issues](#login-issues) below).
+:::
+
+### Login Issues (App Password method)
+
+The following applies when you sign in using the **App Password** tab. If you use **Bluesky (OAuth)** (v3.0.0+), see the note at the top of this section.
 
 **Error Message:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/zh/get-started-for-facebook.md
+++ b/docs/zh/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. 登录 Bluesky
 
-输入您的 Bluesky 句柄（或电子邮件）和[应用密码](https://bsky.app/settings/app-passwords)。
+**自 v3.0.0 起**可使用 OAuth（推荐）或 App Password 登录。详见[入门指南](/zh/get-started)。
 
 ::: tip
 如果遇到登录错误，请参阅[故障排除指南](/troubleshooting)。

--- a/docs/zh/get-started-for-facebook.md
+++ b/docs/zh/get-started-for-facebook.md
@@ -41,7 +41,7 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. 登录 Bluesky
 
-**自 v3.0.0 起**可使用 OAuth（推荐）或 App Password 登录。详见[入门指南](/zh/get-started)。
+**自 v3.0.0 起**可使用浏览器登录（OAuth，推荐）或 App Password 登录。详见[入门指南](/zh/get-started)。
 
 ::: tip
 如果遇到登录错误，请参阅[故障排除指南](/troubleshooting)。

--- a/docs/zh/get-started.md
+++ b/docs/zh/get-started.md
@@ -63,11 +63,11 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 **自 v3.0.0 起**，您可以使用以下任一方式登录：
 
-- **Bluesky（OAuth）**（推荐）：输入您的手柄并点击「Sign in with Bluesky」。浏览器将打开以进行安全的 OAuth 登录，无需应用密码。
+- **Bluesky（浏览器登录）**（推荐，OAuth）：输入您的手柄并点击「Sign in with Bluesky」。浏览器将打开以登录，无需应用密码。
 - **App Password**：切换到「App Password」标签页，输入您的 Bluesky 句柄（或电子邮件）和 [App password](https://bsky.app/settings/app-passwords)。
 
 ::: info 版本说明
-OAuth 登录自 **v3.0.0** 起可用。若使用更早版本，仅支持 App Password 方式。
+浏览器登录（OAuth）自 **v3.0.0** 起可用。若使用更早版本，仅支持 App Password 方式。
 :::
 
 ::: tip

--- a/docs/zh/get-started.md
+++ b/docs/zh/get-started.md
@@ -61,7 +61,14 @@ https://support.mozilla.org/en-US/kb/extensions-button
 
 ### 3. 登录 Bluesky
 
-输入您的 Bluesky 句柄（或电子邮件）和 [App password](https://bsky.app/settings/app-passwords)。
+**自 v3.0.0 起**，您可以使用以下任一方式登录：
+
+- **Bluesky（OAuth）**（推荐）：输入您的手柄并点击「Sign in with Bluesky」。浏览器将打开以进行安全的 OAuth 登录，无需应用密码。
+- **App Password**：切换到「App Password」标签页，输入您的 Bluesky 句柄（或电子邮件）和 [App password](https://bsky.app/settings/app-passwords)。
+
+::: info 版本说明
+OAuth 登录自 **v3.0.0** 起可用。若使用更早版本，仅支持 App Password 方式。
+:::
 
 ::: tip
 如果遇到登录错误，请参阅 [故障排除指南](/troubleshooting)。

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## 身份验证错误
 
-::: info 使用 Bluesky（OAuth）登录 — v3.0.0 起
-自 **v3.0.0** 起，您可选择「Bluesky」标签，输入手柄并点击「Sign in with Bluesky」通过 OAuth 登录。浏览器将打开登录页面，无需应用密码。若 OAuth 遇到问题，可尝试「App Password」标签（见下方[登录问题](#登录问题-app-password-方式)）。
+::: info 浏览器登录（OAuth）— v3.0.0 起
+自 **v3.0.0** 起，您可选择「Bluesky」标签，输入手柄并点击「Sign in with Bluesky」在浏览器中登录（OAuth）。无需应用密码。若遇到问题，可尝试「App Password」标签（见下方[登录问题](#登录问题-app-password-方式)）。
 :::
 
 ### 登录问题（App Password 方式）
 
-以下内容适用于使用 **App Password** 标签登录时。若使用 **Bluesky（OAuth）**（v3.0.0 起），请参阅本小节开头的说明。
+以下内容适用于使用 **App Password** 标签登录时。若使用 **浏览器登录（OAuth）**（v3.0.0 起），请参阅本小节开头的说明。
 
 **错误信息:**  
 <span class="error-message">Error: Invalid identifier or password</span>

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -2,7 +2,13 @@
 
 ## 身份验证错误
 
-### 登录问题
+::: info 使用 Bluesky（OAuth）登录 — v3.0.0 起
+自 **v3.0.0** 起，您可选择「Bluesky」标签，输入手柄并点击「Sign in with Bluesky」通过 OAuth 登录。浏览器将打开登录页面，无需应用密码。若 OAuth 遇到问题，可尝试「App Password」标签（见下方[登录问题](#登录问题-app-password-方式)）。
+:::
+
+### 登录问题（App Password 方式）
+
+以下内容适用于使用 **App Password** 标签登录时。若使用 **Bluesky（OAuth）**（v3.0.0 起），请参阅本小节开头的说明。
 
 **错误信息:**  
 <span class="error-message">Error: Invalid identifier or password</span>


### PR DESCRIPTION
## Summary
Added documentation for the new OAuth sign-in method introduced in v3.0.0 across README and multi-language docs.

## Changes

### Documentation
- **get-started.md** (all locales): Updated "3. Sign in to Bluesky" section for v3.0.0+
  - Documented both Bluesky OAuth (recommended) and App Password options
  - Noted that OAuth is available from v3.0.0
- **troubleshooting.md** (all locales): Added OAuth (v3.0.0+) info to authentication error section, clarified that "Login issues" applies to App Password
- **get-started-for-*.md** (per-platform): Added note about OAuth/App Password options in v3.0.0 with links to localized get-started guides

### Supported locales
en, ja, zh, pt, ko, it, fr, es, de

### Other
- **de/get-started.md**: Added missing "3. Bei Bluesky anmelden" section

## Merge target
Intended to merge into `feat/bluesky-oauth` so documentation ships alongside the OAuth feature.