### PR TITLE
feat: add custom PDS support for App Password login

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle oder E-Mail",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "Service URL",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Fehler: Bitte geben Sie Ihren Handle ein.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle or Email",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "Service URL",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Error: Please enter your handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle o correo electrónico",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "URL del servicio",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Error: Por favor, introduce tu handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle ou e-mail",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "URL du service",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Erreur : Veuillez saisir votre handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle o email",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "URL del servizio",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Errore: Inserisci il tuo handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -27,6 +27,10 @@
     "message": "ハンドルまたはメールアドレス",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "サービスURL",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "エラー: ハンドルを入力してください。",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -27,6 +27,10 @@
     "message": "핸들 또는 이메일",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "서비스 URL",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "오류: 핸들을 입력하세요.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/pt_BR/messages.json
+++ b/locales/pt_BR/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle ou e-mail",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "URL do serviço",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Erro: Por favor, insira seu handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/pt_PT/messages.json
+++ b/locales/pt_PT/messages.json
@@ -27,6 +27,10 @@
     "message": "Handle ou e-mail",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "URL do serviço",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "Erro: Por favor, insira o seu handle.",
     "description": "Text for the error message when the handle is not entered"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -27,6 +27,10 @@
     "message": "用户名或邮箱",
     "description": "Text for the handle or email input on App Password tab"
   },
+  "service_url": {
+    "message": "服务 URL",
+    "description": "Text for the service URL input on App Password tab"
+  },
   "error_enter_identifier": {
     "message": "错误：请输入用户名",
     "description": "Text for the error message when the handle is not entered"

--- a/src/components/popup/AuthForm.tsx
+++ b/src/components/popup/AuthForm.tsx
@@ -12,6 +12,8 @@ interface AuthFormProps {
   isShowAuthFactorTokenInput: boolean;
   authMethod: AuthMethod;
   setAuthMethod: (value: AuthMethod) => void;
+  service: string;
+  setService: (value: string) => void;
   onSubmit: (e: React.FormEvent) => void;
 }
 
@@ -26,6 +28,8 @@ export const AuthForm = ({
   isShowAuthFactorTokenInput,
   authMethod,
   setAuthMethod,
+  service,
+  setService,
   onSubmit,
 }: AuthFormProps) => {
   return (
@@ -106,6 +110,34 @@ export const AuthForm = ({
                 placeholder="xxxx-xxxx-xxxx-xxxx"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                className="input input-bordered input-sm w-full max-w-xs focus:outline-none mt-1"
+              />
+            </label>
+
+            <label className="w-full block mt-2" htmlFor="service">
+              <div className="text-sm flex gap-2 items-center">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418"
+                  />
+                </svg>
+                {chrome.i18n.getMessage("service_url")}
+              </div>
+              <input
+                type="text"
+                name="service"
+                placeholder={`https://${BSKY_DOMAIN}`}
+                value={service}
+                onChange={(e) => setService(e.target.value)}
                 className="input input-bordered input-sm w-full max-w-xs focus:outline-none mt-1"
               />
             </label>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -29,6 +29,7 @@ export const useAuth = () => {
   const [isShowAuthFactorTokenInput, setIsShowAuthFactorTokenInput] =
     useState(false);
   const [authMethod, setAuthMethod] = useState<AuthMethod>("oauth");
+  const [service, setService] = useState(`https://${BSKY_DOMAIN}`);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isAuthenticatedLoading, setIsAuthenticatedLoading] = useState(true);
   const [displayName, setDisplayName] = useState("");
@@ -218,7 +219,7 @@ export const useAuth = () => {
         identifier: formattedIdentifier,
         password,
         authFactorToken: authFactorToken || undefined,
-        service: `https://${BSKY_DOMAIN}`,
+        service,
         authMethod: "app-password",
       },
     });
@@ -308,6 +309,8 @@ export const useAuth = () => {
     isAuthenticatedLoading,
     displayName,
     avatar,
+    service,
+    setService,
     login,
     logout,
   };

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -26,6 +26,8 @@ function IndexPopup() {
     errorMessage: authMessage,
     isAuthenticated,
     isAuthenticatedLoading,
+    service,
+    setService,
     login,
     logout,
     displayName,
@@ -60,6 +62,8 @@ function IndexPopup() {
           isShowAuthFactorTokenInput={isShowAuthFactorTokenInput}
           authMethod={authMethod}
           setAuthMethod={setAuthMethod}
+          service={service}
+          setService={setService}
           onSubmit={login}
         />
       ) : (


### PR DESCRIPTION
## Summary
- Add "Service URL" input field to the App Password tab (default: `https://bsky.social`)
- Allow users running self-hosted PDS instances to log in by specifying a custom PDS endpoint
- i18n support added for all 10 locales

## Test plan
- [ ] Service URL field is displayed with default `https://bsky.social` on App Password tab
- [ ] Service URL field is hidden on OAuth tab
- [ ] Login works with default bsky.social using App Password
- [ ] Custom PDS URL is used for login request when specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)