### PR TITLE
feat: add account autocomplete to OAuth login

### DIFF
--- a/src/background/messages/searchActorsTypeahead.ts
+++ b/src/background/messages/searchActorsTypeahead.ts
@@ -1,0 +1,23 @@
+import { AtpAgent } from "@atproto/api";
+import type { PlasmoMessaging } from "@plasmohq/messaging";
+
+const agent = new AtpAgent({ service: "https://public.api.bsky.app" });
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const { q, limit = 8 } = req.body;
+  try {
+    const { data } = await agent.app.bsky.actor.searchActorsTypeahead({
+      q,
+      limit,
+    });
+    res.send({ actors: data.actors });
+  } catch (e) {
+    res.send({
+      error: {
+        message: e.message,
+      },
+    });
+  }
+};
+
+export default handler;

--- a/src/components/popup/AuthForm.tsx
+++ b/src/components/popup/AuthForm.tsx
@@ -1,5 +1,7 @@
 import type { AuthMethod } from "~hooks/useAuth";
+import { useTypeaheadSearch } from "~hooks/useTypeaheadSearch";
 import { BSKY_DOMAIN } from "~lib/constants";
+import { TypeaheadDropdown } from "./TypeaheadDropdown";
 
 interface AuthFormProps {
   isLoading: boolean;
@@ -14,7 +16,7 @@ interface AuthFormProps {
   setAuthMethod: (value: AuthMethod) => void;
   service: string;
   setService: (value: string) => void;
-  onSubmit: (e: React.FormEvent) => void;
+  onSubmit: (e?: React.FormEvent, identifierOverride?: string) => void;
 }
 
 export const AuthForm = ({
@@ -32,6 +34,23 @@ export const AuthForm = ({
   setService,
   onSubmit,
 }: AuthFormProps) => {
+  const {
+    suggestions,
+    isSearching,
+    showDropdown,
+    activeIndex,
+    onInputChange,
+    onSelect,
+    onClose,
+    onFocus,
+    onKeyDown,
+  } = useTypeaheadSearch({
+    identifier,
+    setIdentifier,
+    onLogin: (handle) => onSubmit(undefined, handle),
+    authMethod,
+  });
+
   return (
     <div className="mt-5">
       <div role="tablist" className="tabs tabs-bordered tabs-sm">
@@ -74,14 +93,28 @@ export const AuthForm = ({
               ? chrome.i18n.getMessage("handle_or_email")
               : chrome.i18n.getMessage("handle")}
           </div>
-          <input
-            type="text"
-            name="identifier"
-            placeholder={`your-username.${BSKY_DOMAIN}`}
-            value={identifier}
-            onChange={(e) => setIdentifier(e.target.value)}
-            className="input input-bordered input-sm w-full max-w-xs focus:outline-none mt-1"
-          />
+          <div className="relative">
+            <input
+              type="text"
+              name="identifier"
+              placeholder={`your-username.${BSKY_DOMAIN}`}
+              value={identifier}
+              onChange={(e) => onInputChange(e.target.value)}
+              onKeyDown={onKeyDown}
+              onFocus={onFocus}
+              onBlur={() => setTimeout(onClose, 150)}
+              autoComplete="off"
+              className="input input-bordered input-sm w-full max-w-xs focus:outline-none mt-1"
+            />
+            {authMethod === "oauth" && showDropdown && (
+              <TypeaheadDropdown
+                suggestions={suggestions}
+                isSearching={isSearching}
+                activeIndex={activeIndex}
+                onSelect={onSelect}
+              />
+            )}
+          </div>
         </label>
 
         {authMethod === "app-password" && (

--- a/src/components/popup/TypeaheadDropdown.tsx
+++ b/src/components/popup/TypeaheadDropdown.tsx
@@ -1,0 +1,74 @@
+import type { AppBskyActorDefs } from "@atproto/api";
+import { useEffect, useRef } from "react";
+
+interface TypeaheadDropdownProps {
+  suggestions: AppBskyActorDefs.ProfileViewBasic[];
+  isSearching: boolean;
+  activeIndex: number;
+  onSelect: (handle: string) => void;
+}
+
+export const TypeaheadDropdown = ({
+  suggestions,
+  isSearching,
+  activeIndex,
+  onSelect,
+}: TypeaheadDropdownProps) => {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      const activeItem = listRef.current.children[activeIndex] as HTMLElement;
+      activeItem?.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex]);
+
+  return (
+    <ul
+      ref={listRef}
+      className="absolute z-50 top-full left-0 w-full bg-base-200 border border-base-content/20 rounded-lg shadow-lg overflow-y-auto mt-1"
+      style={{ maxHeight: "176px" }}
+    >
+      {isSearching && (
+        <li className="px-3 py-3 text-center">
+          <span className="loading loading-spinner loading-xs" />
+        </li>
+      )}
+      {!isSearching &&
+        suggestions.map((actor, i) => (
+          <li
+            key={actor.did}
+            className={`flex items-center gap-3 px-3 py-2.5 cursor-pointer transition-colors ${
+              i === activeIndex
+                ? "bg-primary text-primary-content"
+                : "hover:bg-base-300"
+            }`}
+            onMouseDown={() => onSelect(actor.handle)}
+          >
+            {actor.avatar ? (
+              <img
+                src={actor.avatar}
+                alt=""
+                className="w-8 h-8 rounded-full flex-shrink-0 object-cover"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-base-300 flex-shrink-0" />
+            )}
+            <div className="flex flex-col overflow-hidden min-w-0">
+              <span className="text-sm font-semibold truncate">
+                {actor.displayName || actor.handle}
+              </span>
+              <span className="text-xs opacity-50 truncate">
+                @{actor.handle}
+              </span>
+            </div>
+          </li>
+        ))}
+      {!isSearching && suggestions.length === 0 && (
+        <li className="px-3 py-3 text-xs text-center opacity-60">
+          No results
+        </li>
+      )}
+    </ul>
+  );
+};

--- a/src/components/popup/TypeaheadDropdown.tsx
+++ b/src/components/popup/TypeaheadDropdown.tsx
@@ -65,9 +65,7 @@ export const TypeaheadDropdown = ({
           </li>
         ))}
       {!isSearching && suggestions.length === 0 && (
-        <li className="px-3 py-3 text-xs text-center opacity-60">
-          No results
-        </li>
+        <li className="px-3 py-3 text-xs text-center opacity-60">No results</li>
       )}
     </ul>
   );

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -146,11 +146,14 @@ export const useAuth = () => {
     [applyProfile],
   );
 
-  const login = async (e?: React.FormEvent) => {
+  const login = async (e?: React.FormEvent, identifierOverride?: string) => {
     if (e) {
       e.preventDefault();
     }
-    if (!validateForm()) {
+    if (identifierOverride) {
+      setIdentifier(identifierOverride);
+    }
+    if (!identifierOverride && !validateForm()) {
       return;
     }
     await saveIdentifierToStorage();
@@ -162,7 +165,7 @@ export const useAuth = () => {
       if (authMethod === "app-password") {
         await loginWithAppPassword();
       } else {
-        await loginWithOAuth();
+        await loginWithOAuth(identifierOverride);
       }
     } catch (_e) {
       setErrorMessage(
@@ -174,9 +177,12 @@ export const useAuth = () => {
     }
   };
 
-  const loginWithOAuth = async () => {
+  const loginWithOAuth = async (identifierOverride?: string) => {
+    const rawIdentifier = identifierOverride ?? identifier;
     const formattedIdentifier = (
-      identifier.includes(".") ? identifier : `${identifier}.${BSKY_DOMAIN}`
+      rawIdentifier.includes(".")
+        ? rawIdentifier
+        : `${rawIdentifier}.${BSKY_DOMAIN}`
     ).replace(/^@/, "");
 
     const { session, profile, error } = await sendToBackground({

--- a/src/hooks/useTypeaheadSearch.ts
+++ b/src/hooks/useTypeaheadSearch.ts
@@ -1,0 +1,168 @@
+import type { AppBskyActorDefs } from "@atproto/api";
+import { sendToBackground } from "@plasmohq/messaging";
+import { useCallback, useRef, useState } from "react";
+import type { AuthMethod } from "./useAuth";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+
+interface UseTypeaheadSearchProps {
+  identifier: string;
+  setIdentifier: (value: string) => void;
+  onLogin: (identifierOverride: string) => void;
+  authMethod: AuthMethod;
+}
+
+export const useTypeaheadSearch = ({
+  identifier,
+  setIdentifier,
+  onLogin,
+  authMethod,
+}: UseTypeaheadSearchProps) => {
+  const [suggestions, setSuggestions] = useState<
+    AppBskyActorDefs.ProfileViewBasic[]
+  >([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestCounterRef = useRef(0);
+
+  const search = useCallback(async (query: string) => {
+    const requestId = ++requestCounterRef.current;
+    setIsSearching(true);
+    try {
+      const { actors, error } = await sendToBackground({
+        name: "searchActorsTypeahead",
+        body: { q: query, limit: 8 },
+      });
+      if (requestId !== requestCounterRef.current) return;
+      if (error) {
+        setSuggestions([]);
+        return;
+      }
+      setSuggestions(actors || []);
+      setShowDropdown(true);
+    } catch {
+      if (requestId === requestCounterRef.current) {
+        setSuggestions([]);
+      }
+    } finally {
+      if (requestId === requestCounterRef.current) {
+        setIsSearching(false);
+      }
+    }
+  }, []);
+
+  const onInputChange = useCallback(
+    (value: string) => {
+      setIdentifier(value);
+      setActiveIndex(-1);
+
+      if (authMethod !== "oauth") return;
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      if (value.length < MIN_QUERY_LENGTH) {
+        setSuggestions([]);
+        setShowDropdown(false);
+        setIsSearching(false);
+        return;
+      }
+
+      setIsSearching(true);
+      setShowDropdown(true);
+      debounceRef.current = setTimeout(() => {
+        search(value);
+      }, DEBOUNCE_MS);
+    },
+    [authMethod, setIdentifier, search],
+  );
+
+  const onSelect = useCallback(
+    (handle: string) => {
+      setIdentifier(handle);
+      setShowDropdown(false);
+      setSuggestions([]);
+      onLogin(handle);
+    },
+    [setIdentifier, onLogin],
+  );
+
+  const onClose = useCallback(() => {
+    setShowDropdown(false);
+  }, []);
+
+  const onFocus = useCallback(() => {
+    if (
+      authMethod === "oauth" &&
+      suggestions.length > 0 &&
+      identifier.length >= MIN_QUERY_LENGTH
+    ) {
+      setShowDropdown(true);
+    }
+  }, [authMethod, suggestions.length, identifier.length]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (authMethod !== "oauth" || !showDropdown) return;
+
+      const isDown = e.key === "ArrowDown" || (e.ctrlKey && e.key === "n");
+      const isUp = e.key === "ArrowUp" || (e.ctrlKey && e.key === "p");
+
+      if (isDown) {
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : 0,
+        );
+      } else if (isUp) {
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev > 0 ? prev - 1 : suggestions.length - 1,
+        );
+      }
+
+      switch (e.key) {
+        case "Enter":
+          if (activeIndex >= 0 && activeIndex < suggestions.length) {
+            e.preventDefault();
+            onSelect(suggestions[activeIndex].handle);
+          }
+          break;
+        case "Escape":
+          setShowDropdown(false);
+          setActiveIndex(-1);
+          break;
+      }
+    },
+    [authMethod, showDropdown, suggestions, activeIndex, onSelect],
+  );
+
+  if (authMethod !== "oauth") {
+    return {
+      suggestions: [] as AppBskyActorDefs.ProfileViewBasic[],
+      isSearching: false,
+      showDropdown: false,
+      activeIndex: -1,
+      onInputChange: (value: string) => setIdentifier(value),
+      onSelect: () => {},
+      onClose: () => {},
+      onFocus: () => {},
+      onKeyDown: () => {},
+    };
+  }
+
+  return {
+    suggestions,
+    isSearching,
+    showDropdown,
+    activeIndex,
+    onInputChange,
+    onSelect,
+    onClose,
+    onFocus,
+    onKeyDown,
+  };
+};


### PR DESCRIPTION
## Summary
- Add typeahead (autocomplete) search to the Handle input field on the OAuth tab
- Uses the unauthenticated public API (`app.bsky.actor.searchActorsTypeahead`) to display matching account suggestions in a dropdown (avatar + display name + handle) as the user types
- Clicking or pressing Enter on a suggestion immediately starts the OAuth login flow
- Keyboard navigation support (Arrow keys, Ctrl+N/P, Enter, Escape)

<img width="444" height="395" alt="image" src="https://github.com/user-attachments/assets/14e5b9b5-4bb4-4725-94b1-ba32754052e9" />

## Test plan
- [x] Start extension with `npm run dev`, type a handle on the OAuth tab → suggestions appear
- [x] Click a suggestion → OAuth login flow starts
- [x] Keyboard navigation (↑↓, Ctrl+N/P, Enter, Escape) works correctly
- [x] No suggestions appear on the App Password tab
- [x] `npm run check` / `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)